### PR TITLE
User can edit/delete entries

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,12 +10,31 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyAnimeReport">
-        <activity android:name=".activities.AnimeDetailsActivity"></activity>
-        <activity android:name=".activities.EntryDetailsActivity" />
-        <activity android:name=".activities.EntryActivity" />
-        <activity android:name=".activities.SignupActivity" />
-        <activity android:name=".activities.MainActivity" />
-        <activity android:name=".activities.LoginActivity">
+
+        <activity
+            android:name=".activities.AnimeDetailsActivity"
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".activities.EntryDetailsActivity"
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".activities.EntryActivity"
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".activities.SignupActivity"
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".activities.MainActivity"
+            android:screenOrientation="portrait"/>
+
+        <activity
+            android:name=".activities.LoginActivity"
+            android:screenOrientation="portrait">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -23,5 +42,4 @@
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyAnimeReport">
+        <activity android:name=".activities.AnimeDetailsActivity"></activity>
         <activity android:name=".activities.EntryDetailsActivity" />
         <activity android:name=".activities.EntryActivity" />
         <activity android:name=".activities.SignupActivity" />

--- a/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 
 import android.os.Bundle;
+import android.view.View;
 
 import com.bumptech.glide.Glide;
 import com.example.myanimereport.R;
@@ -27,8 +28,15 @@ public class AnimeDetailsActivity extends AppCompatActivity {
         binding = ActivityAnimeDetailsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        // Hide status bar
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+
+        // Hide action bar
+        if (getSupportActionBar() != null) getSupportActionBar().hide();
+
         // Fill in anime's info
         Anime anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
+        Glide.with(this).load(anime.getBannerImage()).into(binding.ivBanner);
         Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
         binding.tvTitle.setText(anime.getTitleEnglish());
         binding.tvYear.setText(String.format(Locale.getDefault(), "%d", anime.getSeasonYear()));
@@ -36,6 +44,13 @@ public class AnimeDetailsActivity extends AppCompatActivity {
         binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
         binding.tvDescription.setText(anime.getDescription());
         binding.cvAnime.setStrokeColor(anime.getColor());
+
+        binding.nestedScrollView.post(() -> {
+            int targetPosition = binding.ivBanner.getHeight() - binding.appBar.getHeight();
+            binding.nestedScrollView.smoothScrollTo(0, targetPosition);
+        });
+
+        //binding.nestedScrollView.scrollTo(0, binding.tvDescription.getBottom());
 
         // Fill in genres chip group
         ChipGroup cgGenres = binding.cgGenres;

--- a/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
@@ -50,8 +50,6 @@ public class AnimeDetailsActivity extends AppCompatActivity {
             binding.nestedScrollView.smoothScrollTo(0, targetPosition);
         });
 
-        //binding.nestedScrollView.scrollTo(0, binding.tvDescription.getBottom());
-
         // Fill in genres chip group
         ChipGroup cgGenres = binding.cgGenres;
         cgGenres.removeAllViews();

--- a/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
@@ -1,0 +1,52 @@
+package com.example.myanimereport.activities;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import android.os.Bundle;
+
+import com.bumptech.glide.Glide;
+import com.example.myanimereport.R;
+import com.example.myanimereport.databinding.ActivityAnimeDetailsBinding;
+import com.example.myanimereport.databinding.ActivityEntryDetailsBinding;
+import com.example.myanimereport.models.Anime;
+import com.google.android.material.chip.Chip;
+import com.google.android.material.chip.ChipGroup;
+
+import org.parceler.Parcels;
+
+import java.util.Locale;
+
+public class AnimeDetailsActivity extends AppCompatActivity {
+
+    ActivityAnimeDetailsBinding binding;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityAnimeDetailsBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        // Fill in anime's info
+        Anime anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
+        Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
+        binding.tvTitle.setText(anime.getTitleEnglish());
+        binding.tvYear.setText(String.format(Locale.getDefault(), "%d", anime.getSeasonYear()));
+        binding.tvEpisodes.setText(String.format(Locale.getDefault(), "%d Episodes", anime.getEpisodes()));
+        binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
+        binding.tvDescription.setText(anime.getDescription());
+        binding.cvAnime.setStrokeColor(anime.getColor());
+
+        // Fill in genres chip group
+        ChipGroup cgGenres = binding.cgGenres;
+        cgGenres.removeAllViews();
+        for (String genre: anime.getGenres()) {
+            Chip chip = new Chip(this);
+            chip.setText(genre);
+            chip.setChipBackgroundColorResource(R.color.white);
+            chip.setTextColor(ContextCompat.getColor(this, R.color.dark_gray));
+            chip.setEnabled(false);
+            cgGenres.addView(chip);
+        }
+    }
+}

--- a/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
@@ -2,20 +2,16 @@ package com.example.myanimereport.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
-
 import android.os.Bundle;
+import android.text.Html;
 import android.view.View;
-
 import com.bumptech.glide.Glide;
 import com.example.myanimereport.R;
 import com.example.myanimereport.databinding.ActivityAnimeDetailsBinding;
-import com.example.myanimereport.databinding.ActivityEntryDetailsBinding;
 import com.example.myanimereport.models.Anime;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
-
 import org.parceler.Parcels;
-
 import java.util.Locale;
 
 public class AnimeDetailsActivity extends AppCompatActivity {
@@ -28,10 +24,8 @@ public class AnimeDetailsActivity extends AppCompatActivity {
         binding = ActivityAnimeDetailsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        // Hide status bar
+        // Hide status bar and action bar
         getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
-
-        // Hide action bar
         if (getSupportActionBar() != null) getSupportActionBar().hide();
 
         // Fill in anime's info
@@ -39,12 +33,18 @@ public class AnimeDetailsActivity extends AppCompatActivity {
         Glide.with(this).load(anime.getBannerImage()).into(binding.ivBanner);
         Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
         binding.tvTitle.setText(anime.getTitleEnglish());
-        binding.tvYear.setText(String.format(Locale.getDefault(), "%d", anime.getSeasonYear()));
-        binding.tvEpisodes.setText(String.format(Locale.getDefault(), "%d Episodes", anime.getEpisodes()));
-        binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
-        binding.tvDescription.setText(anime.getDescription());
+        binding.tvDescription.setText(Html.fromHtml(anime.getDescription()));
         binding.cvAnime.setStrokeColor(anime.getColor());
 
+        // Handle values that may be null - hide the views
+        if (anime.getSeasonYear() == null) binding.llYear.setVisibility(View.GONE);
+        else binding.tvYear.setText(String.format(Locale.getDefault(), "%d", anime.getSeasonYear()));
+        if (anime.getEpisodes() == null) binding.llEpisodes.setVisibility(View.GONE);
+        else binding.tvEpisodes.setText(String.format(Locale.getDefault(), "%d Episodes", anime.getEpisodes()));
+        if (anime.getAverageScore() == null) binding.llRating.setVisibility(View.GONE);
+        else binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
+
+        // Scroll down a bit so that the poster doesn't take up the whole card view
         binding.nestedScrollView.post(() -> {
             int targetPosition = binding.ivBanner.getHeight() - binding.appBar.getHeight();
             binding.nestedScrollView.smoothScrollTo(0, targetPosition);

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -26,11 +26,11 @@ import java.util.Locale;
 
 public class EntryActivity extends AppCompatActivity {
 
+    private final String[] months = new DateFormatSymbols().getMonths(); // To convert month string and int
     private ActivityEntryBinding binding;
+    private Integer mode; // 0 for creating a new entry; 1 for editing an existing entry
     private Integer mediaId; // The mediaId of the entry's anime, -1 if not found
     private Integer searchMediaId; // The mediaId of the closest anime returned by the GraphQL query
-    private final String[] months = new DateFormatSymbols().getMonths(); // To convert month string and in
-    private int mode; // 0 for creating a new entry; 1 for editing an existing entry
     private Entry entry; // The entry being edited
 
     @Override
@@ -207,11 +207,12 @@ public class EntryActivity extends AppCompatActivity {
         else updateExistingEntry(month, year, Double.parseDouble(rating), note);
     }
 
-    /* Creates a new entry, saves it, and return to the main activity. */
+    /* Creates a new entry, saves it, and return to the home list. */
     public void createNewEntry(Integer month, Integer year, Double rating, String note) {
         entry = new Entry(mediaId, month, year, rating, note);
         entry.saveInBackground(e -> {
             if (e == null) {
+                // Pass back the entry so it can be inserted in the recycler view
                 Toast.makeText(EntryActivity.this, "Entry created.", Toast.LENGTH_SHORT).show();
                 Intent intent = new Intent();
                 intent.putExtra("entry", entry);
@@ -232,6 +233,7 @@ public class EntryActivity extends AppCompatActivity {
         entry.setNote(note);
         entry.saveInBackground(e -> {
             if (e == null) {
+                // Pass back the entry so it can be redrawn in the entry details activity
                 Toast.makeText(EntryActivity.this, "Entry updated.", Toast.LENGTH_SHORT).show();
                 Intent intent = new Intent();
                 intent.putExtra("entry", entry);

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -69,6 +69,7 @@ public class EntryActivity extends AppCompatActivity {
             binding.npMonthWatched.setValue(entry.getMonthWatched());
             binding.npYearWatched.setValue(entry.getYearWatched());
             binding.etRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
+            binding.etNote.setText(entry.getNote());
         }
 
 

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -18,8 +18,10 @@ import com.example.MediaDetailsByTitleQuery;
 import com.example.fragment.MediaFragment;
 import com.example.myanimereport.R;
 import com.example.myanimereport.databinding.ActivityEntryBinding;
+import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.models.ParseApplication;
+import org.parceler.Parcels;
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Locale;
@@ -32,6 +34,7 @@ public class EntryActivity extends AppCompatActivity {
     private Integer mediaId; // The mediaId of the entry's anime, -1 if not found
     private Integer searchMediaId; // The mediaId of the closest anime returned by the GraphQL query
     private Entry entry; // The entry being edited
+    private Anime anime; // The anime of the entry
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -65,7 +68,8 @@ public class EntryActivity extends AppCompatActivity {
             mediaId = entry.getMediaId();
 
             // Populate the views
-            binding.etTitle.setText(getIntent().getStringExtra("title"));
+            anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
+            binding.etTitle.setText(anime.getTitleEnglish());
             binding.npMonthWatched.setValue(entry.getMonthWatched());
             binding.npYearWatched.setValue(entry.getYearWatched());
             binding.etRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
@@ -228,6 +232,7 @@ public class EntryActivity extends AppCompatActivity {
     /* Updates an existing entry with the newly filled information. */
     private void updateExistingEntry(Integer month, Integer year, Double rating, String note) {
         entry.setMediaId(mediaId);
+        entry.setAnime();
         entry.setMonthWatched(month);
         entry.setYearWatched(year);
         entry.setRating(rating);
@@ -238,6 +243,7 @@ public class EntryActivity extends AppCompatActivity {
                 Toast.makeText(EntryActivity.this, "Entry updated.", Toast.LENGTH_SHORT).show();
                 Intent intent = new Intent();
                 intent.putExtra("entry", entry);
+                intent.putExtra("anime", Parcels.wrap(entry.getAnime()));
                 setResult(RESULT_OK, intent);
                 finish();
             } else {

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -218,6 +218,7 @@ public class EntryActivity extends AppCompatActivity {
     /* Creates a new entry, saves it, and return to the home list. */
     public void createNewEntry(Integer month, Integer year, Double rating, String note) {
         entry = new Entry(mediaId, month, year, rating, note);
+        entry.setAnime();
         entry.saveInBackground(e -> {
             if (e == null) {
                 // Pass back the entry so it can be inserted in the recycler view

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -42,6 +42,9 @@ public class EntryActivity extends AppCompatActivity {
         binding = ActivityEntryBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        // Hide status bar
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+
         // Hide action bar
         if (getSupportActionBar() != null) getSupportActionBar().hide();
 

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -22,13 +22,16 @@ import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.models.ParseApplication;
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
+import java.util.Locale;
 
 public class EntryActivity extends AppCompatActivity {
 
     private ActivityEntryBinding binding;
     private Integer mediaId; // The mediaId of the entry's anime, -1 if not found
     private Integer searchMediaId; // The mediaId of the closest anime returned by the GraphQL query
-    private final String[] months = new DateFormatSymbols().getMonths(); // To convert month string and int
+    private final String[] months = new DateFormatSymbols().getMonths(); // To convert month string and in
+    private int mode; // 0 for creating a new entry; 1 for editing an existing entry
+    private Entry entry; // The entry being edited
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,8 +42,35 @@ public class EntryActivity extends AppCompatActivity {
         // Hide action bar
         if (getSupportActionBar() != null) getSupportActionBar().hide();
 
-        // Creating a new entry, mediaId has not been found
-        mediaId = -1;
+        // Set up focus change and click listeners
+        binding.etTitle.setOnFocusChangeListener(this::etOnChangeFocus);
+        binding.etNote.setOnFocusChangeListener(this::etOnChangeFocus);
+        binding.etRating.setOnFocusChangeListener(this::etOnChangeFocus);
+        binding.tvTitle.setOnClickListener(this::tvTitleOnClick);
+
+        // Set up number pickers for month and year
+        setUpNumberPickers();
+
+        // Determine if creating or editing
+        if (!getIntent().hasExtra("entry")) {
+            // Creating a new entry, mediaId has not been found
+            mode = 0;
+            binding.tvToolbar.setText(R.string.add_entry);
+            mediaId = -1;
+        } else {
+            // Editing an existing entry, set the entry to be the one passed in
+            mode = 1;
+            binding.tvToolbar.setText(R.string.edit_entry);
+            entry = getIntent().getParcelableExtra("entry");
+            mediaId = entry.getMediaId();
+
+            // Populate the views
+            binding.etTitle.setText(getIntent().getStringExtra("title"));
+            binding.npMonthWatched.setValue(entry.getMonthWatched());
+            binding.npYearWatched.setValue(entry.getYearWatched());
+            binding.etRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
+        }
+
 
         // Add text changed listener to the title search bar
         binding.etTitle.addTextChangedListener(new TextWatcher() {
@@ -55,15 +85,6 @@ public class EntryActivity extends AppCompatActivity {
             @Override
             public void afterTextChanged(Editable s) { }
         });
-
-        // Set up focus change and click listeners
-        binding.etTitle.setOnFocusChangeListener(this::etOnChangeFocus);
-        binding.etNote.setOnFocusChangeListener(this::etOnChangeFocus);
-        binding.etRating.setOnFocusChangeListener(this::etOnChangeFocus);
-        binding.tvTitle.setOnClickListener(this::tvTitleOnClick);
-
-        // Set up number pickers for month and year
-        setUpNumberPickers();
     }
 
     /* When user clicks the suggested title, set the title to the suggested title. */
@@ -182,11 +203,36 @@ public class EntryActivity extends AppCompatActivity {
             return;
         }
 
-        // Create a new entry, save it, and return to the main activity
-        Entry entry = new Entry(mediaId, month, year, Double.parseDouble(rating), note);
+        if (mode == 0) createNewEntry(month, year, Double.parseDouble(rating), note);
+        else updateExistingEntry(month, year, Double.parseDouble(rating), note);
+    }
+
+    /* Creates a new entry, saves it, and return to the main activity. */
+    public void createNewEntry(Integer month, Integer year, Double rating, String note) {
+        entry = new Entry(mediaId, month, year, rating, note);
         entry.saveInBackground(e -> {
             if (e == null) {
-                Toast.makeText(EntryActivity.this, "Entry saved.", Toast.LENGTH_SHORT).show();
+                Toast.makeText(EntryActivity.this, "Entry created.", Toast.LENGTH_SHORT).show();
+                Intent intent = new Intent();
+                intent.putExtra("entry", entry);
+                setResult(RESULT_OK, intent);
+                finish();
+            } else {
+                Toast.makeText(EntryActivity.this, e.getMessage(), Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    /* Updates an existing entry with the newly filled information. */
+    private void updateExistingEntry(Integer month, Integer year, Double rating, String note) {
+        entry.setMediaId(mediaId);
+        entry.setMonthWatched(month);
+        entry.setYearWatched(year);
+        entry.setRating(rating);
+        entry.setNote(note);
+        entry.saveInBackground(e -> {
+            if (e == null) {
+                Toast.makeText(EntryActivity.this, "Entry updated.", Toast.LENGTH_SHORT).show();
                 Intent intent = new Intent();
                 intent.putExtra("entry", entry);
                 setResult(RESULT_OK, intent);

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -1,5 +1,6 @@
 package com.example.myanimereport.activities;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityOptionsCompat;
 
@@ -7,6 +8,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Toast;
 import com.bumptech.glide.Glide;
 import com.example.myanimereport.databinding.ActivityEntryDetailsBinding;
@@ -17,6 +19,8 @@ import java.util.Locale;
 
 import com.example.myanimereport.models.ParseApplication;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.dialog.MaterialDialogs;
+
 import org.parceler.Parcels;
 
 public class EntryDetailsActivity extends AppCompatActivity {
@@ -87,7 +91,7 @@ public class EntryDetailsActivity extends AppCompatActivity {
     /* Prompts a confirm dialog and deletes the entry. */
     public void btnDeleteOnClick(View view) {
         // Using a Material Dialog with layout defined in res/values/themes.xml
-        new MaterialAlertDialogBuilder(this)
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(this)
             .setTitle("Delete Entry")
             .setMessage("Are you sure?")
             .setPositiveButton("Delete", (dialog, which) -> entry.deleteInBackground(e -> {
@@ -103,7 +107,11 @@ public class EntryDetailsActivity extends AppCompatActivity {
                 }
             }))
             .setNegativeButton("Cancel", (dialog, which) -> dialog.cancel())
-            .show();
+            .create();
+
+        // Hide status bar of the alert dialog's window
+        alertDialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE, WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
+        alertDialog.show();
     }
 
     /* After returning from a entry edit activity, update the entry. */

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -1,9 +1,12 @@
 package com.example.myanimereport.activities;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
 
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -22,6 +25,8 @@ import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.models.ParseApplication;
 import java.text.DateFormatSymbols;
 import java.util.Locale;
+import com.example.myanimereport.R;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class EntryDetailsActivity extends AppCompatActivity {
 
@@ -81,10 +86,12 @@ public class EntryDetailsActivity extends AppCompatActivity {
         );
     }
 
+    /* Shows the anime's details. */
     public void btnInfoOnClick(View view) {
         Toast.makeText(this, "Not implemented", Toast.LENGTH_SHORT).show();
     }
 
+    /* Navigates to the Entry Activity to edit it. */
     public void btnEditOnClick(View view) {
         Intent intent = new Intent(EntryDetailsActivity.this, EntryActivity.class);
         intent.putExtra("entry", entry); // Pass in the entry to edit
@@ -92,8 +99,32 @@ public class EntryDetailsActivity extends AppCompatActivity {
         startActivityForResult(intent, EDIT_ENTRY_REQUEST_CODE);
     }
 
+    /* Prompts a confirm dialog and deletes the entry. */
     public void btnDeleteOnClick(View view) {
-        Toast.makeText(this, "Not implemented", Toast.LENGTH_SHORT).show();
+        new MaterialAlertDialogBuilder(this)
+            .setTitle("Delete Entry")
+            .setMessage("Are you sure?")
+            .setPositiveButton("Delete", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    entry.saveInBackground(e -> {
+                        if (e == null) {
+                            Toast.makeText(EntryDetailsActivity.this, "Entry deleted.", Toast.LENGTH_SHORT).show();
+                            Intent intent = new Intent();
+                            intent.putExtra("position", position);
+                            setResult(RESULT_OK, intent);
+                            finish();
+                        } else {
+                            Toast.makeText(EntryDetailsActivity.this, e.getMessage(), Toast.LENGTH_SHORT).show();
+                        }
+                    });
+                }
+            })
+            .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.cancel();
+                }
+            })
+            .show();
     }
 
     /* After returning from a entry edit activity, update the entry. */

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -1,33 +1,24 @@
 package com.example.myanimereport.activities;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
-import com.apollographql.apollo.ApolloCall;
-import com.apollographql.apollo.api.Response;
-import com.apollographql.apollo.exception.ApolloException;
 import com.bumptech.glide.Glide;
-import com.example.MediaDetailsByIdQuery;
 import com.example.myanimereport.databinding.ActivityEntryDetailsBinding;
 import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
-import com.example.myanimereport.models.ParseApplication;
 import java.text.DateFormatSymbols;
 import java.util.Locale;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-
 import org.parceler.Parcels;
 
 public class EntryDetailsActivity extends AppCompatActivity {
 
     public static final int EDIT_ENTRY_REQUEST_CODE = 3;
 
-    private final String TAG = "EntryDetailsActivity";
     private ActivityEntryDetailsBinding binding;
     private Entry entry; // The entry whose information is being shown
     private Integer position; // The position of the entry in the adapter
@@ -59,6 +50,8 @@ public class EntryDetailsActivity extends AppCompatActivity {
         binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
         binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
         binding.tvNote.setText(entry.getNote());
+
+        // Data related to the anime
         Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
         binding.tvTitle.setText(anime.getTitleEnglish());
         binding.cvEntry.setStrokeColor(anime.getColor());
@@ -73,7 +66,7 @@ public class EntryDetailsActivity extends AppCompatActivity {
     public void btnEditOnClick(View view) {
         Intent intent = new Intent(EntryDetailsActivity.this, EntryActivity.class);
         intent.putExtra("entry", entry); // Pass in the entry to edit
-        intent.putExtra("title", anime.getTitleEnglish()); // Also pass in the title to reduce queries
+        intent.putExtra("anime", Parcels.wrap(anime)); // Also pass in the anime to reduce queries
         startActivityForResult(intent, EDIT_ENTRY_REQUEST_CODE);
     }
 
@@ -105,6 +98,7 @@ public class EntryDetailsActivity extends AppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == EDIT_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             entry = data.getParcelableExtra("entry");
+            anime = Parcels.unwrap(data.getParcelableExtra("anime"));
             populateEntryView();
         }
     }
@@ -115,6 +109,7 @@ public class EntryDetailsActivity extends AppCompatActivity {
         Intent intent = new Intent();
         intent.putExtra("entry", entry);
         intent.putExtra("position", position);
+        intent.putExtra("anime", Parcels.wrap(anime));
         setResult(RESULT_OK, intent);
         finish();
     }

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -21,6 +21,8 @@ import java.text.DateFormatSymbols;
 import java.util.Locale;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.parceler.Parcels;
+
 public class EntryDetailsActivity extends AppCompatActivity {
 
     public static final int EDIT_ENTRY_REQUEST_CODE = 3;
@@ -43,6 +45,7 @@ public class EntryDetailsActivity extends AppCompatActivity {
         // Get the passed in data
         entry = getIntent().getParcelableExtra("entry");
         position = getIntent().getIntExtra("position", -1);
+        anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
 
         // Show the entry's information
         populateEntryView();
@@ -56,28 +59,9 @@ public class EntryDetailsActivity extends AppCompatActivity {
         binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
         binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
         binding.tvNote.setText(entry.getNote());
-
-        // Make a query for the anime's cover image and title
-        Integer mediaId = entry.getMediaId();
-        ParseApplication.apolloClient.query(new MediaDetailsByIdQuery(mediaId)).enqueue(
-            new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
-                @Override
-                public void onResponse(@NonNull Response<MediaDetailsByIdQuery.Data> response) {
-                    // View editing needs to happen in the main thread, not the background thread
-                    ParseApplication.currentActivity.runOnUiThread(() -> {
-                        anime = new Anime(response);
-                        Glide.with(EntryDetailsActivity.this).load(anime.getCoverImage()).into(binding.ivImage);
-                        binding.tvTitle.setText(anime.getTitleEnglish());
-                        binding.cvAnime.setStrokeColor(anime.getColor());
-                    });
-                }
-
-                @Override
-                public void onFailure(@NonNull ApolloException e) {
-                    Log.e(TAG, e.getMessage());
-                }
-            }
-        );
+        Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
+        binding.tvTitle.setText(anime.getTitleEnglish());
+        binding.cvEntry.setStrokeColor(anime.getColor());
     }
 
     /* Shows the anime's details. */

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -3,9 +3,14 @@ package com.example.myanimereport.activities;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
+import android.widget.Toast;
+
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
@@ -24,6 +29,8 @@ public class EntryDetailsActivity extends AppCompatActivity {
     private ActivityEntryDetailsBinding binding;
     private Entry entry; // The entry whose information is being shown
     private Integer position; // The position of the entry in the adapter
+    private Anime anime; // The anime of the entry
+    public static final int EDIT_ENTRY_REQUEST_CODE = 3;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,6 +46,12 @@ public class EntryDetailsActivity extends AppCompatActivity {
         position = getIntent().getIntExtra("position", -1);
 
         // Show the entry's information
+        populateEntryView();
+    }
+
+    /* Shows the entry's information. */
+    public void populateEntryView() {
+        // Data unrelated to the anime
         String month = (new DateFormatSymbols().getMonths()[entry.getMonthWatched() - 1]);
         binding.tvMonthWatched.setText(month);
         binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
@@ -48,23 +61,48 @@ public class EntryDetailsActivity extends AppCompatActivity {
         // Make a query for the anime's cover image and title
         Integer mediaId = entry.getMediaId();
         ParseApplication.apolloClient.query(new MediaDetailsByIdQuery(mediaId)).enqueue(
-            new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
-                @Override
-                public void onResponse(@NonNull Response<MediaDetailsByIdQuery.Data> response) {
-                    // View editing needs to happen in the main thread, not the background thread
-                    ParseApplication.currentActivity.runOnUiThread(() -> {
-                        Anime anime = new Anime(response);
-                        Glide.with(EntryDetailsActivity.this).load(anime.getCoverImage()).into(binding.ivImage);
-                        binding.tvTitle.setText(anime.getTitleEnglish());
-                        binding.cvAnime.setStrokeColor(anime.getColor());
-                    });
-                }
+                new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
+                    @Override
+                    public void onResponse(@NonNull Response<MediaDetailsByIdQuery.Data> response) {
+                        // View editing needs to happen in the main thread, not the background thread
+                        ParseApplication.currentActivity.runOnUiThread(() -> {
+                            anime = new Anime(response);
+                            Glide.with(EntryDetailsActivity.this).load(anime.getCoverImage()).into(binding.ivImage);
+                            binding.tvTitle.setText(anime.getTitleEnglish());
+                            binding.cvAnime.setStrokeColor(anime.getColor());
+                        });
+                    }
 
-                @Override
-                public void onFailure(@NonNull ApolloException e) {
-                    Log.e(TAG, e.getMessage());
+                    @Override
+                    public void onFailure(@NonNull ApolloException e) {
+                        Log.e(TAG, e.getMessage());
+                    }
                 }
-            }
         );
+    }
+
+    public void btnInfoOnClick(View view) {
+        Toast.makeText(this, "Not implemented", Toast.LENGTH_SHORT).show();
+    }
+
+    public void btnEditOnClick(View view) {
+        Intent intent = new Intent(EntryDetailsActivity.this, EntryActivity.class);
+        intent.putExtra("entry", entry); // Pass in the entry to edit
+        intent.putExtra("title", anime.getTitleEnglish()); // Also pass in the title to reduce queries
+        startActivityForResult(intent, EDIT_ENTRY_REQUEST_CODE);
+    }
+
+    public void btnDeleteOnClick(View view) {
+        Toast.makeText(this, "Not implemented", Toast.LENGTH_SHORT).show();
+    }
+
+    /* After returning from a entry edit activity, update the entry. */
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == EDIT_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            entry = data.getParcelableExtra("entry");
+            populateEntryView();
+        }
     }
 }

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -99,7 +99,7 @@ public class EntryDetailsActivity extends AppCompatActivity {
         new MaterialAlertDialogBuilder(this)
             .setTitle("Delete Entry")
             .setMessage("Are you sure?")
-            .setPositiveButton("Delete", (dialog, which) -> entry.saveInBackground(e -> {
+            .setPositiveButton("Delete", (dialog, which) -> entry.deleteInBackground(e -> {
                 if (e == null) {
                     // Return to the home list and pass back the position so it can be deleted in the RV
                     Toast.makeText(EntryDetailsActivity.this, "Entry deleted.", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -105,4 +105,13 @@ public class EntryDetailsActivity extends AppCompatActivity {
             populateEntryView();
         }
     }
+
+    @Override
+    public void onBackPressed() {
+        Intent intent = new Intent();
+        intent.putExtra("entry", entry);
+        intent.putExtra("position", position);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
 }

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -1,6 +1,8 @@
 package com.example.myanimereport.activities;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityOptionsCompat;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -12,6 +14,8 @@ import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
 import java.text.DateFormatSymbols;
 import java.util.Locale;
+
+import com.example.myanimereport.models.ParseApplication;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.parceler.Parcels;
 
@@ -59,7 +63,14 @@ public class EntryDetailsActivity extends AppCompatActivity {
 
     /* Shows the anime's details. */
     public void btnInfoOnClick(View view) {
-        Toast.makeText(this, "Not implemented", Toast.LENGTH_SHORT).show();
+        Intent intent = new Intent(EntryDetailsActivity.this, AnimeDetailsActivity.class);
+        intent.putExtra("anime", Parcels.wrap(anime));
+
+        // Animate the transition
+        Activity activity = ParseApplication.currentActivity;
+        ActivityOptionsCompat options = ActivityOptionsCompat
+                .makeSceneTransitionAnimation(activity, binding.cvEntry, "card");
+        startActivity(intent, options.toBundle());
     }
 
     /* Navigates to the Entry Activity to edit it. */

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -34,6 +34,9 @@ public class EntryDetailsActivity extends AppCompatActivity {
         binding = ActivityEntryDetailsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        // Hide status bar
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+
         // Hide action bar
         if (getSupportActionBar() != null) getSupportActionBar().hide();
 

--- a/app/src/main/java/com/example/myanimereport/activities/LoginActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/LoginActivity.java
@@ -18,6 +18,12 @@ public class LoginActivity extends AppCompatActivity {
         binding = ActivityLoginBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        // Hide status bar
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+
+        // Hide action bar
+        if (getSupportActionBar() != null) getSupportActionBar().hide();
+
         // Check if user is already logged in
         if (ParseUser.getCurrentUser() != null) goMainActivity();
     }

--- a/app/src/main/java/com/example/myanimereport/activities/MainActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/MainActivity.java
@@ -1,6 +1,8 @@
 package com.example.myanimereport.activities;
 
 import android.os.Bundle;
+import android.view.View;
+
 import com.example.myanimereport.R;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
@@ -18,6 +20,9 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         ActivityMainBinding binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        // Hide status bar
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
 
         // Hide action bar
         if (getSupportActionBar() != null) getSupportActionBar().hide();

--- a/app/src/main/java/com/example/myanimereport/activities/SignupActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/SignupActivity.java
@@ -17,6 +17,12 @@ public class SignupActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivitySignupBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        // Hide status bar
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+
+        // Hide action bar
+        if (getSupportActionBar() != null) getSupportActionBar().hide();
     }
 
     /* Returns to the login page. */

--- a/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
+++ b/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
@@ -1,5 +1,6 @@
 package com.example.myanimereport.adapters;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
@@ -7,6 +8,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
+import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 import com.apollographql.apollo.ApolloCall;
@@ -20,6 +23,9 @@ import com.example.myanimereport.fragments.HomeFragment;
 import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.models.ParseApplication;
+
+import org.parceler.Parcels;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -112,9 +118,16 @@ public class EntriesAdapter extends RecyclerView.Adapter<EntriesAdapter.ViewHold
         @Override
         public void onClick(View v) {
             Intent intent = new Intent(context, EntryDetailsActivity.class);
-            intent.putExtra("entry", entries.get(getAdapterPosition())); // Pass in the entry
+            Entry entry = entries.get(getAdapterPosition());
+            intent.putExtra("entry", entry); // Pass in the entry
             intent.putExtra("position", getAdapterPosition()); // Pass in its position in the list
-            fragment.startActivityForResult(intent, HomeFragment.VIEW_ENTRY_REQUEST_CODE);
+            intent.putExtra("anime", Parcels.wrap(entry.getAnime())); // Pass in the entry's anime
+
+            // Animate the transition
+            Activity activity = ParseApplication.currentActivity;
+            ActivityOptionsCompat options = ActivityOptionsCompat
+                    .makeSceneTransitionAnimation(activity, binding.cvEntry, "card");
+            fragment.startActivityForResult(intent, HomeFragment.VIEW_ENTRY_REQUEST_CODE, options.toBundle());
         }
     }
 }

--- a/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
+++ b/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
@@ -9,7 +9,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityOptionsCompat;
-import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 import com.apollographql.apollo.ApolloCall;
@@ -23,9 +22,7 @@ import com.example.myanimereport.fragments.HomeFragment;
 import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.models.ParseApplication;
-
 import org.parceler.Parcels;
-
 import java.util.List;
 import java.util.Locale;
 

--- a/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
+++ b/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
@@ -93,6 +93,7 @@ public class EntriesAdapter extends RecyclerView.Adapter<EntriesAdapter.ViewHold
                         // View editing needs to happen in the main thread, not the background thread
                         ParseApplication.currentActivity.runOnUiThread(() -> {
                             Anime anime = new Anime(response);
+                            entry.setAnime(anime);
                             loadAnimeData(anime);
                         });
                     }
@@ -114,8 +115,15 @@ public class EntriesAdapter extends RecyclerView.Adapter<EntriesAdapter.ViewHold
         /* When the entry card is clicked, expand it to show its full information. */
         @Override
         public void onClick(View v) {
-            Intent intent = new Intent(context, EntryDetailsActivity.class);
+            // Check if anime data has been set
             Entry entry = entries.get(getAdapterPosition());
+            if (entry.getAnime() == null) {
+                entry.setAnime();
+                return;
+            }
+
+            // Navigate to the entry details activity
+            Intent intent = new Intent(context, EntryDetailsActivity.class);
             intent.putExtra("entry", entry); // Pass in the entry
             intent.putExtra("position", getAdapterPosition()); // Pass in its position in the list
             intent.putExtra("anime", Parcels.wrap(entry.getAnime())); // Pass in the entry's anime

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -129,7 +129,7 @@ public class HomeFragment extends Fragment {
             } else {
                 // Entry deleted
                 entries.remove(position);
-                adapter.notifyItemRemoved(0);
+                adapter.notifyItemRemoved(position);
             }
         }
     }

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -78,7 +78,7 @@ public class HomeFragment extends Fragment {
     public void queryEntries(int skip) {
         ParseQuery<Entry> query = ParseQuery.getQuery(Entry.class); // Specify type of data
         query.setSkip(skip); // Skip the first skip items
-        query.setLimit(10); // Limit query to 20 items
+        query.setLimit(10); // Limit query to 10 items
         query.whereEqualTo(Entry.KEY_USER, ParseUser.getCurrentUser()); // Limit entries to current user's
         query.addDescendingOrder("createdAt"); // Order posts by creation date
         query.findInBackground((entriesFound, e) -> { // Start async query for entries
@@ -89,10 +89,7 @@ public class HomeFragment extends Fragment {
             }
 
             // Add entries to the recycler view and notify its adapter of new data
-            for (Entry entry: entriesFound) {
-                entry.setAnime();
-                entries.add(entry);
-            }
+            entries.addAll(entriesFound);
             adapter.notifyDataSetChanged();
         });
     }
@@ -116,7 +113,10 @@ public class HomeFragment extends Fragment {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == NEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             // A new entry was created, add it to the front of the list
-            entries.add(0, data.getParcelableExtra("entry"));
+            Entry entry = data.getParcelableExtra("entry");
+            Anime anime = Parcels.unwrap(data.getParcelableExtra("anime"));
+            entry.setAnime(anime);
+            entries.add(0, entry);
             adapter.notifyItemInserted(0);
             binding.rvEntries.smoothScrollToPosition(0); // Scroll to the top to see the new entry
         }
@@ -127,10 +127,9 @@ public class HomeFragment extends Fragment {
             if (data.hasExtra("entry")) {
                 // Entry updated
                 Entry entry = data.getParcelableExtra("entry");
-                Anime anime = Parcels.unwrap(data.getParcelableExtra("anime"));
-                entry.setAnime(anime);
                 entries.set(position, entry);
                 adapter.notifyItemChanged(position);
+                entry.setAnime();
             } else {
                 // Entry deleted
                 entries.remove(position);

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -17,10 +17,12 @@ import com.example.myanimereport.activities.EntryActivity;
 import com.example.myanimereport.activities.LoginActivity;
 import com.example.myanimereport.adapters.EntriesAdapter;
 import com.example.myanimereport.databinding.FragmentHomeBinding;
+import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.utils.EndlessRecyclerViewScrollListener;
 import com.parse.ParseQuery;
 import com.parse.ParseUser;
+import org.parceler.Parcels;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -124,7 +126,10 @@ public class HomeFragment extends Fragment {
             int position = data.getIntExtra("position", -1);
             if (data.hasExtra("entry")) {
                 // Entry updated
-                entries.set(position, data.getParcelableExtra("entry"));
+                Entry entry = data.getParcelableExtra("entry");
+                Anime anime = Parcels.unwrap(data.getParcelableExtra("anime"));
+                entry.setAnime(anime);
+                entries.set(position, entry);
                 adapter.notifyItemChanged(position);
             } else {
                 // Entry deleted

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -26,12 +26,13 @@ import java.util.List;
 
 public class HomeFragment extends Fragment {
 
+    public static final int NEW_ENTRY_REQUEST_CODE = 1;
+    public static final int VIEW_ENTRY_REQUEST_CODE = 2;
+
     private final String TAG = "HomeFragment";
     private FragmentHomeBinding binding;
     private List<Entry> entries;
     private EntriesAdapter adapter;
-    public static final int NEW_ENTRY_REQUEST_CODE = 1;
-    public static final int VIEW_ENTRY_REQUEST_CODE = 2;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -112,12 +113,14 @@ public class HomeFragment extends Fragment {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == NEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            // A new entry was created, add it to the front of the list
             entries.add(0, data.getParcelableExtra("entry"));
             adapter.notifyItemInserted(0);
             binding.rvEntries.smoothScrollToPosition(0); // Scroll to the top to see the new entry
         }
 
         if (requestCode == VIEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            // Returning from an entry details activity
             int position = data.getIntExtra("position", -1);
             if (data.hasExtra("entry")) {
                 // Entry updated

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -78,7 +78,7 @@ public class HomeFragment extends Fragment {
     public void queryEntries(int skip) {
         ParseQuery<Entry> query = ParseQuery.getQuery(Entry.class); // Specify type of data
         query.setSkip(skip); // Skip the first skip items
-        query.setLimit(20); // Limit query to 20 items
+        query.setLimit(10); // Limit query to 20 items
         query.whereEqualTo(Entry.KEY_USER, ParseUser.getCurrentUser()); // Limit entries to current user's
         query.addDescendingOrder("createdAt"); // Order posts by creation date
         query.findInBackground((entriesFound, e) -> { // Start async query for entries

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -119,8 +119,15 @@ public class HomeFragment extends Fragment {
 
         if (requestCode == VIEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             int position = data.getIntExtra("position", -1);
-            entries.set(position, data.getParcelableExtra("entry"));
-            adapter.notifyItemChanged(position);
+            if (data.hasExtra("entry")) {
+                // Entry updated
+                entries.set(position, data.getParcelableExtra("entry"));
+                adapter.notifyItemChanged(position);
+            } else {
+                // Entry deleted
+                entries.remove(position);
+                adapter.notifyItemRemoved(0);
+            }
         }
     }
 

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -114,8 +114,6 @@ public class HomeFragment extends Fragment {
         if (requestCode == NEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             // A new entry was created, add it to the front of the list
             Entry entry = data.getParcelableExtra("entry");
-            Anime anime = Parcels.unwrap(data.getParcelableExtra("anime"));
-            entry.setAnime(anime);
             entries.add(0, entry);
             adapter.notifyItemInserted(0);
             binding.rvEntries.smoothScrollToPosition(0); // Scroll to the top to see the new entry
@@ -129,7 +127,6 @@ public class HomeFragment extends Fragment {
                 Entry entry = data.getParcelableExtra("entry");
                 entries.set(position, entry);
                 adapter.notifyItemChanged(position);
-                entry.setAnime();
             } else {
                 // Entry deleted
                 entries.remove(position);

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -74,7 +74,7 @@ public class HomeFragment extends Fragment {
         });
     }
 
-    /* Queries the entries 20 at a time. Skips the first skip items. */
+    /* Queries the entries 10 at a time. Skips the first skip items. */
     public void queryEntries(int skip) {
         ParseQuery<Entry> query = ParseQuery.getQuery(Entry.class); // Specify type of data
         query.setSkip(skip); // Skip the first skip items

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SimpleItemAnimator;
 import com.example.myanimereport.activities.EntryActivity;
 import com.example.myanimereport.activities.LoginActivity;
 import com.example.myanimereport.adapters.EntriesAdapter;
@@ -49,6 +50,10 @@ public class HomeFragment extends Fragment {
         adapter = new EntriesAdapter(this, entries);
         binding.rvEntries.setLayoutManager(layoutManager);
         binding.rvEntries.setAdapter(adapter);
+
+        // Remove the default on-change animations of the recycler view
+        SimpleItemAnimator animator = (SimpleItemAnimator) binding.rvEntries.getItemAnimator();
+        if (animator != null) animator.setSupportsChangeAnimations(false);
 
         // Button listeners
         binding.btnLogOut.setOnClickListener(this::logOutOnClick);
@@ -109,6 +114,13 @@ public class HomeFragment extends Fragment {
         if (requestCode == NEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             entries.add(0, data.getParcelableExtra("entry"));
             adapter.notifyItemInserted(0);
+            binding.rvEntries.smoothScrollToPosition(0); // Scroll to the top to see the new entry
+        }
+
+        if (requestCode == VIEW_ENTRY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            int position = data.getIntExtra("position", -1);
+            entries.set(position, data.getParcelableExtra("entry"));
+            adapter.notifyItemChanged(position);
         }
     }
 

--- a/app/src/main/java/com/example/myanimereport/fragments/MatchFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/MatchFragment.java
@@ -5,16 +5,19 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
+
 import com.bumptech.glide.Glide;
 import com.example.myanimereport.R;
 import com.example.myanimereport.databinding.FragmentMatchBinding;
 import com.example.myanimereport.models.Anime;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
+
 import java.util.Locale;
 
 public class MatchFragment extends Fragment {

--- a/app/src/main/java/com/example/myanimereport/models/Anime.java
+++ b/app/src/main/java/com/example/myanimereport/models/Anime.java
@@ -26,6 +26,7 @@ public class Anime {
     private String bannerImage; // URL of the banner image of the media
     private List<String> genres; // List of genres of the media
     private String color; // Primary color of the cover image
+    private Integer episodes; // Number of episodes
 
     /* Default constructor. */
     public Anime() {
@@ -44,12 +45,13 @@ public class Anime {
         genres.add("drama");
         genres.add("science fiction");
         color = "#000000";
+        episodes = 1000;
     }
 
     /* Alternative constructor. */
     public Anime(Integer mediaId, String titleEnglish, String titleRomaji, String titleNative,
                  String description, Double averageScore, Integer seasonYear, String coverImage,
-                 String bannerImage, List<String> genres, String color) {
+                 String bannerImage, List<String> genres, String color, Integer episodes) {
         this.mediaId = mediaId;
         this.titleEnglish = titleEnglish;
         this.titleRomaji = titleRomaji;
@@ -61,6 +63,7 @@ public class Anime {
         this.bannerImage = bannerImage;
         this.genres = genres;
         this.color = color;
+        this.episodes = episodes;
     }
 
     /* Alternative constructor (from GraphQL response object). */
@@ -77,6 +80,7 @@ public class Anime {
         this.bannerImage = media.bannerImage();
         this.genres = media.genres();
         this.color = media.coverImage().color();
+        this.episodes = media.episodes();
     }
 
     /* Getters. */
@@ -118,5 +122,9 @@ public class Anime {
 
     public Integer getColor() {
         return color != null? Color.parseColor(color): Color.parseColor("#EEEEEE");
+    }
+
+    public Integer getEpisodes() {
+        return episodes;
     }
 }

--- a/app/src/main/java/com/example/myanimereport/models/Anime.java
+++ b/app/src/main/java/com/example/myanimereport/models/Anime.java
@@ -7,10 +7,13 @@ import com.example.MediaDetailsByIdQuery;
 import com.example.fragment.MediaFragment;
 import com.example.myanimereport.R;
 
+import org.parceler.Parcel;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /* A media object from the AniList API. */
+@Parcel
 public class Anime {
     private Integer mediaId; // Unique id for the anime in the AniList database
     private String titleEnglish; // The official English title

--- a/app/src/main/java/com/example/myanimereport/models/Anime.java
+++ b/app/src/main/java/com/example/myanimereport/models/Anime.java
@@ -74,7 +74,9 @@ public class Anime {
         this.titleRomaji = media.title().romaji();
         this.titleNative = media.title().native_();
         this.description = media.description();
-        this.averageScore = media.averageScore() / 10.0;
+        if (media.averageScore() != null) {
+            this.averageScore = media.averageScore() / 10.0;
+        }
         this.seasonYear = media.seasonYear();
         this.coverImage = media.coverImage().extraLarge();
         this.bannerImage = media.bannerImage();

--- a/app/src/main/java/com/example/myanimereport/models/Entry.java
+++ b/app/src/main/java/com/example/myanimereport/models/Entry.java
@@ -1,21 +1,14 @@
 package com.example.myanimereport.models;
 
-import android.content.Context;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
-
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
-import com.bumptech.glide.Glide;
 import com.example.MediaDetailsByIdQuery;
-import com.example.myanimereport.databinding.ItemEntryBinding;
 import com.parse.ParseClassName;
 import com.parse.ParseObject;
 import com.parse.ParseUser;
-import org.jetbrains.annotations.NotNull;
-import java.util.Locale;
 
 /* Entry (Parse model). */
 @ParseClassName("Entry")
@@ -36,7 +29,6 @@ public class Entry extends ParseObject {
     public Entry(Integer mediaId, Integer monthWatched, Integer yearWatched, Double rating, String note) {
         setUser(ParseUser.getCurrentUser());
         setMediaId(mediaId);
-        //setAnime();
         setMonthWatched(monthWatched);
         setYearWatched(yearWatched);
         setRating(rating);
@@ -49,6 +41,7 @@ public class Entry extends ParseObject {
     }
 
     public void setAnime() {
+        System.out.println("SET ANIME");
         ParseApplication.apolloClient.query(new MediaDetailsByIdQuery(getMediaId())).enqueue(
             new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
                 @Override

--- a/app/src/main/java/com/example/myanimereport/models/Entry.java
+++ b/app/src/main/java/com/example/myanimereport/models/Entry.java
@@ -34,6 +34,7 @@ public class Entry extends ParseObject {
 
     /* Alternative constructor. */
     public Entry(Integer mediaId, Integer monthWatched, Integer yearWatched, Double rating, String note) {
+        setAnime();
         setUser(ParseUser.getCurrentUser());
         setMediaId(mediaId);
         setMonthWatched(monthWatched);
@@ -61,6 +62,10 @@ public class Entry extends ParseObject {
                 }
             }
         );
+    }
+
+    public void setAnime(Anime anime) {
+        this.anime = anime;
     }
 
     public ParseUser getUser() {

--- a/app/src/main/java/com/example/myanimereport/models/Entry.java
+++ b/app/src/main/java/com/example/myanimereport/models/Entry.java
@@ -34,9 +34,9 @@ public class Entry extends ParseObject {
 
     /* Alternative constructor. */
     public Entry(Integer mediaId, Integer monthWatched, Integer yearWatched, Double rating, String note) {
-        setAnime();
         setUser(ParseUser.getCurrentUser());
         setMediaId(mediaId);
+        //setAnime();
         setMonthWatched(monthWatched);
         setYearWatched(yearWatched);
         setRating(rating);

--- a/app/src/main/res/drawable/ic_baseline_live_tv_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_live_tv_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M21,6h-7.59l3.29,-3.29L16,2l-4,4 -4,-4 -0.71,0.71L10.59,6L3,6c-1.1,0 -2,0.89 -2,2v12c0,1.1 0.9,2 2,2h18c1.1,0 2,-0.9 2,-2L23,8c0,-1.11 -0.9,-2 -2,-2zM21,20L3,20L3,8h18v12zM9,10v8l7,-4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_anime_details.xml
+++ b/app/src/main/res/layout/activity_anime_details.xml
@@ -24,20 +24,41 @@
             app:layout_scrollFlags="scroll|enterAlways">
 
             <TextView
+                android:id="@+id/tvToolbar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Anime Details"
+                android:text="@string/anime_details"
                 android:textSize="20sp"
                 android:textStyle="bold"
                 android:textColor="@color/white" />
         </androidx.appcompat.widget.Toolbar>
     </com.google.android.material.appbar.AppBarLayout>
 
+    <FrameLayout
+        android:id="@+id/flBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/ivBanner"
+            android:layout_width="match_parent"
+            android:layout_height="130dp"
+            android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            tools:src="@tools:sample/backgrounds/scenic" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="bottom"
+            android:background="@drawable/fade_bottom"/>
+    </FrameLayout>
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/cvAnime"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/appBar"
+        android:layout_below="@id/flBanner"
         android:layout_marginHorizontal="20dp"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="20dp"

--- a/app/src/main/res/layout/activity_anime_details.xml
+++ b/app/src/main/res/layout/activity_anime_details.xml
@@ -93,7 +93,7 @@
 
                     <View
                         android:layout_width="match_parent"
-                        android:layout_height="400dp"
+                        android:layout_height="200dp"
                         android:layout_gravity="bottom"
                         android:background="@drawable/fade_bottom"/>
                 </FrameLayout>
@@ -110,86 +110,104 @@
                     android:textColor="@color/white"
                     tools:text="Detective Conan" />
 
-                <RelativeLayout
+                <LinearLayout
                     android:id="@+id/rlInfo"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:orientation="horizontal"
                     android:layout_below="@id/tvTitle"
                     android:layout_marginVertical="5dp"
                     android:layout_marginHorizontal="10dp">
 
-                    <ImageView
-                        android:id="@+id/ivYearIcon"
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:layout_centerVertical="true"
-                        android:background="@drawable/ic_baseline_watch_later_24"
-                        android:backgroundTint="@color/yellow" />
-
-                    <TextView
-                        android:id="@+id/tvYear"
+                    <LinearLayout
+                        android:id="@+id/llYear"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_toEndOf="@id/ivYearIcon"
-                        android:layout_marginStart="5dp"
-                        android:layout_centerVertical="true"
-                        android:textSize="16sp"
-                        android:textColor="@color/white"
-                        tools:text="2018" />
+                        android:layout_gravity="center_vertical"
+                        android:orientation="horizontal">
 
-                    <ImageView
-                        android:id="@+id/ivEpisodesIcon"
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:layout_toEndOf="@id/tvYear"
-                        android:layout_marginStart="10dp"
-                        android:layout_centerVertical="true"
-                        android:background="@drawable/ic_baseline_live_tv_24"
-                        android:backgroundTint="@color/yellow" />
+                        <ImageView
+                            android:id="@+id/ivYearIcon"
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:layout_gravity="center_vertical"
+                            android:background="@drawable/ic_baseline_watch_later_24"
+                            android:backgroundTint="@color/yellow" />
 
-                    <TextView
-                        android:id="@+id/tvEpisodes"
+                        <TextView
+                            android:id="@+id/tvYear"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="5dp"
+                            android:layout_gravity="center_vertical"
+                            android:textSize="16sp"
+                            android:textColor="@color/white"
+                            tools:text="2018" />
+                    </LinearLayout>
+
+
+                    <LinearLayout
+                        android:id="@+id/llEpisodes"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_toEndOf="@id/ivEpisodesIcon"
-                        android:layout_marginStart="5dp"
-                        android:layout_centerVertical="true"
-                        android:textSize="16sp"
-                        android:textColor="@color/white"
-                        tools:text="25 Episodes" />
+                        android:layout_gravity="center_vertical"
+                        android:orientation="horizontal">
 
-                    <ImageView
-                        android:id="@+id/ivRatingIcon"
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:layout_toEndOf="@id/tvEpisodes"
-                        android:layout_marginStart="10dp"
-                        android:layout_centerVertical="true"
-                        android:background="@drawable/ic_baseline_star_24"
-                        android:backgroundTint="@color/yellow" />
+                        <ImageView
+                            android:id="@+id/ivEpisodesIcon"
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:layout_marginStart="10dp"
+                            android:layout_gravity="center_vertical"
+                            android:background="@drawable/ic_baseline_live_tv_24"
+                            android:backgroundTint="@color/yellow" />
 
-                    <TextView
-                        android:id="@+id/tvRating"
+                        <TextView
+                            android:id="@+id/tvEpisodes"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="5dp"
+                            android:layout_gravity="center_vertical"                            android:textSize="16sp"
+                            android:textColor="@color/white"
+                            tools:text="25 Episodes" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/llRating"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_toEndOf="@id/ivRatingIcon"
-                        android:layout_marginStart="5dp"
-                        android:layout_centerVertical="true"
-                        android:textSize="20sp"
-                        android:textStyle="bold"
-                        android:textColor="@color/white"
-                        tools:text="9.8" />
+                        android:layout_gravity="center_vertical"
+                        android:orientation="horizontal">
 
-                    <TextView
-                        android:id="@+id/tvRatingOutOf"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_toEndOf="@id/tvRating"
-                        android:layout_centerVertical="true"
-                        android:textSize="16sp"
-                        android:textColor="@color/white"
-                        android:text="@string/_10" />
-                </RelativeLayout>
+                        <ImageView
+                            android:id="@+id/ivRatingIcon"
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:layout_marginStart="10dp"
+                            android:layout_gravity="center_vertical"
+                            android:background="@drawable/ic_baseline_star_24"
+                            android:backgroundTint="@color/yellow" />
+
+                        <TextView
+                            android:id="@+id/tvRating"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="5dp"
+                            android:layout_gravity="center_vertical"
+                            android:textSize="20sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/white"
+                            tools:text="9.8" />
+
+                        <TextView
+                            android:id="@+id/tvRatingOutOf"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"                            android:textSize="16sp"
+                            android:textColor="@color/white"
+                            android:text="@string/_10" />
+                    </LinearLayout>
+                </LinearLayout>
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/cgGenres"

--- a/app/src/main/res/layout/activity_anime_details.xml
+++ b/app/src/main/res/layout/activity_anime_details.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/dark_gray"
+    tools:context=".fragments.MatchFragment">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:elevation="0dp">
+
+        <!-- Toolbar is the actual app bar with text and the action items -->
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/dark_gray"
+            app:layout_scrollFlags="scroll|enterAlways">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Anime Details"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:textColor="@color/white" />
+        </androidx.appcompat.widget.Toolbar>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cvAnime"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/appBar"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="20dp"
+        android:transitionName="card"
+        app:cardCornerRadius="10dp"
+        app:strokeColor="@color/white"
+        app:strokeWidth="1dp">
+
+        <ScrollView
+            android:id="@+id/nestedScrollView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/dark_gray"
+            android:overScrollMode="never">
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <FrameLayout
+                    android:id="@+id/flImage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <ImageView
+                        android:id="@+id/ivImage"
+                        android:layout_width="match_parent"
+                        android:layout_height="400dp"
+                        android:adjustViewBounds="true"
+                        android:scaleType="centerCrop"
+                        tools:src="@tools:sample/backgrounds/scenic" />
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="400dp"
+                        android:layout_gravity="bottom"
+                        android:background="@drawable/fade_bottom"/>
+                </FrameLayout>
+
+                <TextView
+                    android:id="@+id/tvTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/flImage"
+                    android:layout_marginVertical="5dp"
+                    android:layout_marginHorizontal="10dp"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/white"
+                    tools:text="Detective Conan" />
+
+                <RelativeLayout
+                    android:id="@+id/rlInfo"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/tvTitle"
+                    android:layout_marginVertical="5dp"
+                    android:layout_marginHorizontal="10dp">
+
+                    <ImageView
+                        android:id="@+id/ivYearIcon"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_centerVertical="true"
+                        android:background="@drawable/ic_baseline_watch_later_24"
+                        android:backgroundTint="@color/yellow" />
+
+                    <TextView
+                        android:id="@+id/tvYear"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toEndOf="@id/ivYearIcon"
+                        android:layout_marginStart="5dp"
+                        android:layout_centerVertical="true"
+                        android:textSize="16sp"
+                        android:textColor="@color/white"
+                        tools:text="2018" />
+
+                    <ImageView
+                        android:id="@+id/ivEpisodesIcon"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_toEndOf="@id/tvYear"
+                        android:layout_marginStart="10dp"
+                        android:layout_centerVertical="true"
+                        android:background="@drawable/ic_baseline_live_tv_24"
+                        android:backgroundTint="@color/yellow" />
+
+                    <TextView
+                        android:id="@+id/tvEpisodes"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toEndOf="@id/ivEpisodesIcon"
+                        android:layout_marginStart="5dp"
+                        android:layout_centerVertical="true"
+                        android:textSize="16sp"
+                        android:textColor="@color/white"
+                        tools:text="25 Episodes" />
+
+                    <ImageView
+                        android:id="@+id/ivRatingIcon"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:layout_toEndOf="@id/tvEpisodes"
+                        android:layout_marginStart="10dp"
+                        android:layout_centerVertical="true"
+                        android:background="@drawable/ic_baseline_star_24"
+                        android:backgroundTint="@color/yellow" />
+
+                    <TextView
+                        android:id="@+id/tvRating"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toEndOf="@id/ivRatingIcon"
+                        android:layout_marginStart="5dp"
+                        android:layout_centerVertical="true"
+                        android:textSize="20sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/white"
+                        tools:text="9.8" />
+
+                    <TextView
+                        android:id="@+id/tvRatingOutOf"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_toEndOf="@id/tvRating"
+                        android:layout_centerVertical="true"
+                        android:textSize="16sp"
+                        android:textColor="@color/white"
+                        android:text="@string/_10" />
+                </RelativeLayout>
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/cgGenres"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/rlInfo"
+                    android:layout_marginVertical="5dp"
+                    android:layout_marginHorizontal="10dp"
+                    app:chipSpacingHorizontal="5dp"
+                    app:chipSpacingVertical="-10dp" />
+
+                <TextView
+                    android:id="@+id/tvDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/cgGenres"
+                    android:layout_marginVertical="5dp"
+                    android:layout_marginHorizontal="10dp"
+                    android:textSize="16sp"
+                    android:textColor="@color/white"
+                    tools:text="Description of the anime." />
+            </RelativeLayout>
+        </ScrollView>
+    </com.google.android.material.card.MaterialCardView>
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_entry.xml
+++ b/app/src/main/res/layout/activity_entry.xml
@@ -24,6 +24,7 @@
             app:layout_scrollFlags="scroll|enterAlways">
 
             <TextView
+                android:id="@+id/tvToolbar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/entry"

--- a/app/src/main/res/layout/activity_entry_details.xml
+++ b/app/src/main/res/layout/activity_entry_details.xml
@@ -76,13 +76,14 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <com.google.android.material.card.MaterialCardView
-        android:id="@+id/cvAnime"
+        android:id="@+id/cvEntry"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/appBar"
         android:layout_marginHorizontal="20dp"
         android:layout_marginTop="10dp"
         android:layout_marginBottom="20dp"
+        android:transitionName="card"
         app:cardCornerRadius="10dp"
         app:strokeColor="@color/white"
         app:strokeWidth="1dp">
@@ -102,6 +103,7 @@
                     android:id="@+id/flImage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
+
                     <ImageView
                         android:id="@+id/ivImage"
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_entry_details.xml
+++ b/app/src/main/res/layout/activity_entry_details.xml
@@ -45,7 +45,8 @@
                     android:layout_centerVertical="true"
                     android:background="@drawable/theme_rounded_bg"
                     android:src="@drawable/ic_baseline_info_24"
-                    app:tint="@color/dark_gray" />
+                    app:tint="@color/dark_gray"
+                    android:onClick="btnInfoOnClick" />
 
                 <ImageButton
                     android:id="@+id/btnEdit"
@@ -56,7 +57,8 @@
                     android:layout_centerVertical="true"
                     android:background="@drawable/theme_rounded_bg"
                     android:src="@drawable/ic_baseline_edit_24"
-                    app:tint="@color/dark_gray" />
+                    app:tint="@color/dark_gray"
+                    android:onClick="btnEditOnClick" />
 
                 <ImageButton
                     android:id="@+id/btnDelete"
@@ -67,7 +69,8 @@
                     android:layout_centerVertical="true"
                     android:background="@drawable/theme_rounded_bg"
                     android:src="@drawable/ic_baseline_delete_24"
-                    app:tint="@color/dark_gray" />
+                    app:tint="@color/dark_gray"
+                    android:onClick="btnDeleteOnClick" />
             </RelativeLayout>
         </androidx.appcompat.widget.Toolbar>
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/item_entry.xml
+++ b/app/src/main/res/layout/item_entry.xml
@@ -8,9 +8,11 @@
     android:layout_width="match_parent">
 
     <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cvEntry"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_margin="10dp"
+        android:transitionName="card"
         card_view:cardCornerRadius="10dp"
         card_view:strokeColor="@color/white"
         card_view:strokeWidth="1dp">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,4 +12,5 @@
     <color name="dark_gray">#FF222222</color>
     <color name="yellow">#FFFFD600</color>
     <color name="red">#ED4337</color>
+    <color name="transparent">#00000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
     <string name="anime_details">Anime Details</string>
+    <string name="no_data_on_episodes">No data on episodes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="entry_details">Entry Details</string>
     <string name="add_entry">Add Entry</string>
     <string name="edit_entry">Edit Entry</string>
+    <string name="delete_question">Delete?</string>
+    <string name="delete">Delete</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="delete_question">Delete?</string>
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
+    <string name="anime_details">Anime Details</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,6 @@
     <string name="save">Save</string>
     <string name="no_results_found">No results found.</string>
     <string name="entry_details">Entry Details</string>
+    <string name="add_entry">Add Entry</string>
+    <string name="edit_entry">Edit Entry</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MaterialAlertDialog.App" parent="MaterialAlertDialog.MaterialComponents">
+        <item name="shapeAppearance">@style/ShapeAppearance.App.MediumComponent</item>
+    </style>
+
+    <style name="MaterialAlertDialog.App.Title.Text" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">18sp</item>
+    </style>
+
+    <style name="MaterialAlertDialog.App.Body.Text" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">16sp</item>
+    </style>
+
+    <style name="Widget.App.Button" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.Button</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.App.SmallComponent</item>
+    </style>
+
+    <style name="ThemeOverlay.App.Button" parent="">
+        <item name="colorPrimary">@color/white</item>
+        <item name="android:letterSpacing">0</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:background">@drawable/theme_rounded_bg</item>
+        <item name="backgroundTint">@color/transparent</item>
+    </style>
+
+    <style name="ShapeAppearance.App.MediumComponent" parent="ShapeAppearance.MaterialComponents.MediumComponent">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">10dp</item>
+    </style>
+
+    <style name="ShapeAppearance.App.SmallComponent" parent="ShapeAppearance.MaterialComponents.SmallComponent">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">10dp</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,5 +14,17 @@
         <!-- Customize your theme here. -->
         <item name="android:colorControlNormal">@color/white</item>
         <item name="android:textColorPrimary">@color/white</item>
+        <item name="materialAlertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog</item>
+    </style>
+
+    <style name="ThemeOverlay.App.MaterialAlertDialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="colorPrimary">@color/white</item>
+        <item name="colorSecondary">@color/white</item>
+        <item name="colorSurface">@color/dark_gray</item>
+        <item name="alertDialogStyle">@style/MaterialAlertDialog.App</item>
+        <item name="materialAlertDialogTitleTextStyle">@style/MaterialAlertDialog.App.Title.Text</item>
+        <item name="materialAlertDialogBodyTextStyle">@style/MaterialAlertDialog.App.Body.Text</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.App.Button</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.App.Button</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimaryVariant">@color/dark_gray</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondary">@color/theme</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -16,6 +16,8 @@
         <item name="android:textColorPrimary">@color/white</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog</item>
         <item name="android:windowContentTransitions">true</item>
+        <item name="android:windowBackground">@color/black</item>
+        <item name="android:colorBackground">@color/black</item>
     </style>
 
     <style name="ThemeOverlay.App.MaterialAlertDialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,6 +15,7 @@
         <item name="android:colorControlNormal">@color/white</item>
         <item name="android:textColorPrimary">@color/white</item>
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.App.MaterialAlertDialog</item>
+        <item name="android:windowContentTransitions">true</item>
     </style>
 
     <style name="ThemeOverlay.App.MaterialAlertDialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">


### PR DESCRIPTION
# Overview
This allows the user to edit an delete entries.
* When user clicks an entry in the home list, it expands with an enlarging transition animation to show its details
* On the entry details screen, there are buttons to edit or delete the entry.
* When user clicks the edit button, they go to an entry edit screen and update its information. When they click save, they return to the entry details screen and can see the updates (also reflected in the home list).
* When user clicks the delete button, they can confirm/cancel the delete request through a Material Alert Dialog.
* When they confirm the delete, the entry is deleted from Parse and user returns to the home list where the entry gets removed from the recycler view.

# Screen Recording
![edit-delete-entry-with-transition-animation](https://user-images.githubusercontent.com/59420335/125698559-6330e412-e2be-45af-a01d-2881259b504e.gif)


# Resources
* [Material Dialogs](https://material.io/components/dialogs/android)
