### PR TITLE
[Ready for Review] Query animes in bulk + null checking

### DIFF
--- a/app/src/main/graphql/com/example/MediaDetailsByIdList.graphql
+++ b/app/src/main/graphql/com/example/MediaDetailsByIdList.graphql
@@ -1,0 +1,14 @@
+query MediaDetailsByIdList($page:Int!, $id_in:[Int]!) {
+    Page (page: $page, perPage: 50) {
+        pageInfo {
+          total
+          currentPage
+          lastPage
+          hasNextPage
+        }
+
+        media (type: ANIME, id_in: $id_in) {
+          ...mediaFragment
+        }
+    }
+}

--- a/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/AnimeDetailsActivity.java
@@ -30,11 +30,12 @@ public class AnimeDetailsActivity extends AppCompatActivity {
 
         // Fill in anime's info
         Anime anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
-        Glide.with(this).load(anime.getBannerImage()).into(binding.ivBanner);
-        Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
-        binding.tvTitle.setText(anime.getTitleEnglish());
-        binding.tvDescription.setText(Html.fromHtml(anime.getDescription()));
-        binding.cvAnime.setStrokeColor(anime.getColor());
+        if (anime == null) finish();
+        if (anime.getBannerImage() != null) Glide.with(this).load(anime.getBannerImage()).into(binding.ivBanner);
+        if (anime.getCoverImage() != null) Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
+        if (anime.getTitleEnglish() != null) binding.tvTitle.setText(anime.getTitleEnglish());
+        if (anime.getDescription() != null) binding.tvDescription.setText(Html.fromHtml(anime.getDescription()));
+        if (anime.getColor() != null) binding.cvAnime.setStrokeColor(anime.getColor());
 
         // Handle values that may be null - hide the views
         if (anime.getSeasonYear() == null) binding.llYear.setVisibility(View.GONE);
@@ -51,15 +52,17 @@ public class AnimeDetailsActivity extends AppCompatActivity {
         });
 
         // Fill in genres chip group
-        ChipGroup cgGenres = binding.cgGenres;
-        cgGenres.removeAllViews();
-        for (String genre: anime.getGenres()) {
-            Chip chip = new Chip(this);
-            chip.setText(genre);
-            chip.setChipBackgroundColorResource(R.color.white);
-            chip.setTextColor(ContextCompat.getColor(this, R.color.dark_gray));
-            chip.setEnabled(false);
-            cgGenres.addView(chip);
+        if (anime.getGenres() != null) {
+            ChipGroup cgGenres = binding.cgGenres;
+            cgGenres.removeAllViews();
+            for (String genre : anime.getGenres()) {
+                Chip chip = new Chip(this);
+                chip.setText(genre);
+                chip.setChipBackgroundColorResource(R.color.white);
+                chip.setTextColor(ContextCompat.getColor(this, R.color.dark_gray));
+                chip.setEnabled(false);
+                cgGenres.addView(chip);
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/myanimereport/activities/BacklogItemDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/BacklogItemDetailsActivity.java
@@ -46,10 +46,12 @@ public class BacklogItemDetailsActivity extends AppCompatActivity {
 
     /* Shows the backlog item's information. */
     public void populateBacklogItemView() {
-        Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
-        binding.tvTitle.setText(anime.getTitleEnglish());
-        binding.cvItem.setStrokeColor(anime.getColor());
-        binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
+        if (anime == null) finish();
+        if (anime.getCoverImage() != null) Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);
+        if (anime.getTitleEnglish() != null) binding.tvTitle.setText(anime.getTitleEnglish());
+        if (anime.getColor() != null) binding.cvItem.setStrokeColor(anime.getColor());
+        if (anime.getAverageScore() != null) binding.tvRating.setText(String.format(Locale.getDefault(),
+                "%.1f", anime.getAverageScore()));
     }
 
     /* Shows the anime's details. */

--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -25,6 +25,7 @@ import org.parceler.Parcels;
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.Objects;
 
 public class EntryActivity extends AppCompatActivity {
 
@@ -34,7 +35,6 @@ public class EntryActivity extends AppCompatActivity {
     private Integer mediaId; // The mediaId of the entry's anime, -1 if not found
     private Integer searchMediaId; // The mediaId of the closest anime returned by the GraphQL query
     private Entry entry; // The entry being edited
-    private Anime anime; // The anime of the entry
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -71,12 +71,14 @@ public class EntryActivity extends AppCompatActivity {
             mediaId = entry.getMediaId();
 
             // Populate the views
-            anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
-            binding.etTitle.setText(anime.getTitleEnglish());
-            binding.npMonthWatched.setValue(entry.getMonthWatched());
-            binding.npYearWatched.setValue(entry.getYearWatched());
-            binding.etRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
-            binding.etNote.setText(entry.getNote());
+            // The anime of the entry
+            Anime anime = Parcels.unwrap(getIntent().getParcelableExtra("anime"));
+            if (anime == null) return;
+            if (anime.getTitleEnglish() != null) binding.etTitle.setText(anime.getTitleEnglish());
+            if (entry.getMonthWatched() != null) binding.npMonthWatched.setValue(entry.getMonthWatched());
+            if (entry.getYearWatched() != null) binding.npYearWatched.setValue(entry.getYearWatched());
+            if (entry.getRating() != null) binding.etRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
+            if (entry.getNote() != null) binding.etNote.setText(entry.getNote());
         }
 
 
@@ -139,8 +141,9 @@ public class EntryActivity extends AppCompatActivity {
                 public void onResponse(@NonNull Response<MediaDetailsByTitleQuery.Data> response) {
                     // View editing needs to happen on the main thread, not the background thread
                     runOnUiThread(() -> {
-                        // Try to find the English or Romaji title
-                        MediaFragment media = response.getData().Media().fragments().mediaFragment();
+                        // Try to find the English or Romaji title (with null checking)
+                        MediaFragment media = Objects.requireNonNull(Objects.requireNonNull(
+                                response.getData()).Media()).fragments().mediaFragment();
                         String title = media.title().english();
                         if (title == null) title = media.title().romaji();
 

--- a/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryDetailsActivity.java
@@ -3,7 +3,6 @@ package com.example.myanimereport.activities;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityOptionsCompat;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -16,11 +15,8 @@ import com.example.myanimereport.models.Anime;
 import com.example.myanimereport.models.Entry;
 import java.text.DateFormatSymbols;
 import java.util.Locale;
-
 import com.example.myanimereport.models.ParseApplication;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.dialog.MaterialDialogs;
-
 import org.parceler.Parcels;
 
 public class EntryDetailsActivity extends AppCompatActivity {
@@ -57,12 +53,22 @@ public class EntryDetailsActivity extends AppCompatActivity {
 
     /* Shows the entry's information. */
     public void populateEntryView() {
+        if (entry == null || anime == null) finish();
+
         // Data unrelated to the anime
-        String month = (new DateFormatSymbols().getMonths()[entry.getMonthWatched() - 1]);
-        binding.tvMonthWatched.setText(month);
-        binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
-        binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
-        binding.tvNote.setText(entry.getNote());
+        if (entry.getMonthWatched() != null) {
+            String month = (new DateFormatSymbols().getMonths()[entry.getMonthWatched() - 1]);
+            binding.tvMonthWatched.setText(month);
+        }
+        if (entry.getYearWatched() != null) {
+            binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
+        }
+        if (entry.getRating() != null) {
+            binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
+        }
+        if (entry.getNote() != null) {
+            binding.tvNote.setText(entry.getNote());
+        }
 
         // Data related to the anime
         Glide.with(this).load(anime.getCoverImage()).into(binding.ivImage);

--- a/app/src/main/java/com/example/myanimereport/adapters/BacklogItemsAdapter.java
+++ b/app/src/main/java/com/example/myanimereport/adapters/BacklogItemsAdapter.java
@@ -65,8 +65,9 @@ public class BacklogItemsAdapter extends RecyclerView.Adapter<BacklogItemsAdapte
         /* Binds the item's data to the view's components. */
         public void bind(BacklogItem item) {
             Anime anime = item.getAnime();
-            binding.tvTitle.setText(anime.getTitleEnglish());
-            binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
+            if (anime.getTitleEnglish() != null) binding.tvTitle.setText(anime.getTitleEnglish());
+            if (anime.getAverageScore() != null) binding.tvRating.setText(String.format(Locale.getDefault(),
+                    "%.1f", anime.getAverageScore()));
         }
 
         /* When the backlog item is clicked, expand it to show the anime details. */

--- a/app/src/main/java/com/example/myanimereport/adapters/CardStackAdapter.java
+++ b/app/src/main/java/com/example/myanimereport/adapters/CardStackAdapter.java
@@ -64,13 +64,15 @@ public class CardStackAdapter extends RecyclerView.Adapter<CardStackAdapter.View
             });
         }
 
-        /* Binds the anime's data to the view's components. */
+        /* Binds the anime's data to the view's components (with null checking). */
         public void bind(Anime anime) {
-            Glide.with(context).load(anime.getCoverImage()).into(binding.ivImage);
-            binding.tvTitle.setText(anime.getTitleEnglish());
-            binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
-            binding.tvDescription.setText(Html.fromHtml(anime.getDescription()));
-            binding.cvAnime.setStrokeColor(anime.getColor());
+            if (anime == null) return;
+            if (anime.getCoverImage() != null) Glide.with(context).load(anime.getCoverImage()).into(binding.ivImage);
+            if (anime.getTitleEnglish() != null) binding.tvTitle.setText(anime.getTitleEnglish());
+            if (anime.getAverageScore() != null) binding.tvRating.setText(String.format(Locale.getDefault(),
+                    "%.1f", anime.getAverageScore()));
+            if (anime.getDescription() != null) binding.tvDescription.setText(Html.fromHtml(anime.getDescription()));
+            if (anime.getColor() != null) binding.cvAnime.setStrokeColor(anime.getColor());
 
             // Handle values that may be null - hide the views
             if (anime.getSeasonYear() == null) binding.llYear.setVisibility(View.GONE);
@@ -81,15 +83,17 @@ public class CardStackAdapter extends RecyclerView.Adapter<CardStackAdapter.View
             else binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", anime.getAverageScore()));
 
             // Fill in genres chip group
-            ChipGroup cgGenres = binding.cgGenres;
-            cgGenres.removeAllViews();
-            for (String genre: anime.getGenres()) {
-                Chip chip = new Chip(context);
-                chip.setText(genre);
-                chip.setChipBackgroundColorResource(R.color.white);
-                chip.setTextColor(ContextCompat.getColor(context, R.color.dark_gray));
-                chip.setEnabled(false);
-                cgGenres.addView(chip);
+            if (anime.getGenres() != null) {
+                ChipGroup cgGenres = binding.cgGenres;
+                cgGenres.removeAllViews();
+                for (String genre : anime.getGenres()) {
+                    Chip chip = new Chip(context);
+                    chip.setText(genre);
+                    chip.setChipBackgroundColorResource(R.color.white);
+                    chip.setTextColor(ContextCompat.getColor(context, R.color.dark_gray));
+                    chip.setEnabled(false);
+                    cgGenres.addView(chip);
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
+++ b/app/src/main/java/com/example/myanimereport/adapters/EntriesAdapter.java
@@ -76,9 +76,15 @@ public class EntriesAdapter extends RecyclerView.Adapter<EntriesAdapter.ViewHold
 
         /* Binds the entry's data to the view's components. */
         public void bind(Entry entry) {
+            if (entry == null) return;
+
             // Set data unrelated to the anime
-            binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
-            binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
+            if (entry.getYearWatched() != null) {
+                binding.tvYearWatched.setText(String.format(Locale.getDefault(), "%d", entry.getYearWatched()));
+            }
+            if (entry.getRating() != null) {
+                binding.tvRating.setText(String.format(Locale.getDefault(), "%.1f", entry.getRating()));
+            }
 
             // Use pre-queried anime to prevent excessive network requests
             if (entry.getAnime() != null) {
@@ -110,8 +116,8 @@ public class EntriesAdapter extends RecyclerView.Adapter<EntriesAdapter.ViewHold
 
         /* Binds the entry's anime-relevant data to the view's components. */
         public void loadAnimeData(Anime anime) {
-            Glide.with(context).load(anime.getBannerImage()).into(binding.ivImage);
-            binding.tvTitle.setText(anime.getTitleEnglish());
+            if (anime.getBannerImage() != null) Glide.with(context).load(anime.getBannerImage()).into(binding.ivImage);
+            if (anime.getTitleEnglish() != null) binding.tvTitle.setText(anime.getTitleEnglish());
         }
 
         /* When the entry card is clicked, expand it to show its full information. */

--- a/app/src/main/java/com/example/myanimereport/fragments/BacklogFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/BacklogFragment.java
@@ -79,11 +79,8 @@ public class BacklogFragment extends Fragment {
             }
 
             // Add items to the recycler view and notify its adapter of new data
-            for (BacklogItem item: itemsFound) {
-                item.setAnime();
-                ParseApplication.seenMediaIds.add(item.getMediaId());
-                items.add(item);
-            }
+            BacklogItem.setAnimes(itemsFound);
+            items.addAll(itemsFound);
             adapter.notifyDataSetChanged();
         });
     }

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -76,7 +76,7 @@ public class HomeFragment extends Fragment {
     public void queryEntries(int skip) {
         ParseQuery<Entry> query = ParseQuery.getQuery(Entry.class); // Specify type of data
         query.setSkip(skip); // Skip the first skip items
-        query.setLimit(10); // Limit query to 10 items
+        query.setLimit(50); // Limit query to 50 items
         query.whereEqualTo(Entry.KEY_USER, ParseUser.getCurrentUser()); // Limit entries to current user's
         query.addDescendingOrder("createdAt"); // Order posts by creation date
         query.findInBackground((entriesFound, e) -> { // Start async query for entries
@@ -88,7 +88,7 @@ public class HomeFragment extends Fragment {
 
             // Add entries to the recycler view and notify its adapter of new data
             Entry.setAnimes(entriesFound);
-            for (Entry entry: entriesFound) entries.add(entry);
+            entries.addAll(entriesFound);
             adapter.notifyDataSetChanged();
         });
     }

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -87,11 +87,8 @@ public class HomeFragment extends Fragment {
             }
 
             // Add entries to the recycler view and notify its adapter of new data
-            for (Entry entry: entriesFound) {
-                entry.setAnime();
-                ParseApplication.seenMediaIds.add(entry.getMediaId());
-                entries.add(entry);
-            }
+            Entry.setAnimes(entriesFound);
+            for (Entry entry: entriesFound) entries.add(entry);
             adapter.notifyDataSetChanged();
         });
     }

--- a/app/src/main/java/com/example/myanimereport/fragments/MatchFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/MatchFragment.java
@@ -29,6 +29,7 @@ import com.yuyakaido.android.cardstackview.SwipeAnimationSetting;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class MatchFragment extends Fragment implements CardStackListener {
 
@@ -71,7 +72,14 @@ public class MatchFragment extends Fragment implements CardStackListener {
             new ApolloCall.Callback<MediaAllQuery.Data>() {
                 @Override
                 public void onResponse(@NonNull Response<MediaAllQuery.Data> response) {
-                    for (MediaAllQuery.Medium m: response.getData().Page().media()) {
+                    // Null checking
+                    if (response.getData().Page() == null) return;
+                    if (response.getData().Page().media() == null) return;
+                    if (response.getData().Page().pageInfo() == null) return;
+                    if (response.getData().Page().pageInfo().hasNextPage() == null) return;
+
+                    // Add the animes to the list
+                    for (MediaAllQuery.Medium m: Objects.requireNonNull(response.getData().Page().media())) {
                         Anime anime = new Anime(m.fragments().mediaFragment());
                         allAnime.add(anime);
                     }

--- a/app/src/main/java/com/example/myanimereport/fragments/ReportFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/ReportFragment.java
@@ -237,7 +237,7 @@ public class ReportFragment extends Fragment {
         // Create data set
         BarDataSet dataSet = new BarDataSet(barEntries, "Average Rating");
         customizeBarDataSet(dataSet, null, theme, null);
-        chart.setData(new BarData(Arrays.asList(dataSet)));
+        chart.setData(new BarData(Collections.singletonList(dataSet)));
 
         // Customize the chart
         customizeChart(chart, 2);
@@ -278,7 +278,7 @@ public class ReportFragment extends Fragment {
         int i = 0;
         for (String ignored : genreToList.keySet()) colors.add(ColorTemplate.MATERIAL_COLORS[i++%4]);
         customizeBarDataSet(dataSet, genreToList.keySet().toArray(new String[0]), -1, colors);
-        chart.setData(new BarData(Arrays.asList(dataSet)));
+        chart.setData(new BarData(Collections.singletonList(dataSet)));
 
         // Customize the chart
         customizeChart(chart, 3);

--- a/app/src/main/java/com/example/myanimereport/models/Anime.java
+++ b/app/src/main/java/com/example/myanimereport/models/Anime.java
@@ -90,7 +90,7 @@ public class Anime {
         this.titleRomaji = Objects.requireNonNull(media.title()).romaji();
         this.titleNative = Objects.requireNonNull(media.title()).native_();
         this.description = media.description();
-        this.averageScore = Objects.requireNonNull(media.averageScore()) / 10.0;
+        this.averageScore = media.averageScore() != null? media.averageScore() / 10.0: -1;
         this.seasonYear = media.seasonYear();
         this.coverImage = Objects.requireNonNull(media.coverImage()).extraLarge();
         this.bannerImage = media.bannerImage();

--- a/app/src/main/java/com/example/myanimereport/models/Anime.java
+++ b/app/src/main/java/com/example/myanimereport/models/Anime.java
@@ -5,12 +5,10 @@ import android.graphics.Color;
 import com.apollographql.apollo.api.Response;
 import com.example.MediaDetailsByIdQuery;
 import com.example.fragment.MediaFragment;
-import com.example.myanimereport.R;
-
 import org.parceler.Parcel;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /* A media object from the AniList API. */
 @Parcel
@@ -68,38 +66,36 @@ public class Anime {
 
     /* Alternative constructor (from GraphQL response object). */
     public Anime(Response<MediaDetailsByIdQuery.Data> response) {
-        MediaFragment media = response.getData().Media().fragments().mediaFragment();
+
+        MediaFragment media = Objects.requireNonNull(
+                Objects.requireNonNull(response.getData()).Media()).fragments().mediaFragment();
         mediaId = media.id();
-        this.titleEnglish = media.title().english();
-        this.titleRomaji = media.title().romaji();
-        this.titleNative = media.title().native_();
+        this.titleEnglish = Objects.requireNonNull(media.title()).english();
+        this.titleRomaji = Objects.requireNonNull(media.title()).romaji();
+        this.titleNative = Objects.requireNonNull(media.title()).native_();
         this.description = media.description();
-        if (media.averageScore() != null) {
-            this.averageScore = media.averageScore() / 10.0;
-        }
+        this.averageScore = Objects.requireNonNull(media.averageScore()) / 10.0;
         this.seasonYear = media.seasonYear();
-        this.coverImage = media.coverImage().extraLarge();
+        this.coverImage = Objects.requireNonNull(media.coverImage()).extraLarge();
         this.bannerImage = media.bannerImage();
         this.genres = media.genres();
-        this.color = media.coverImage().color();
+        this.color = Objects.requireNonNull(media.coverImage()).color();
         this.episodes = media.episodes();
     }
 
     /* Alternative constructor (from MediaFragment). */
     public Anime(MediaFragment media) {
         mediaId = media.id();
-        this.titleEnglish = media.title().english();
-        this.titleRomaji = media.title().romaji();
-        this.titleNative = media.title().native_();
+        this.titleEnglish = Objects.requireNonNull(media.title()).english();
+        this.titleRomaji = Objects.requireNonNull(media.title()).romaji();
+        this.titleNative = Objects.requireNonNull(media.title()).native_();
         this.description = media.description();
-        if (media.averageScore() != null) {
-            this.averageScore = media.averageScore() / 10.0;
-        }
+        this.averageScore = Objects.requireNonNull(media.averageScore()) / 10.0;
         this.seasonYear = media.seasonYear();
-        this.coverImage = media.coverImage().extraLarge();
+        this.coverImage = Objects.requireNonNull(media.coverImage()).extraLarge();
         this.bannerImage = media.bannerImage();
         this.genres = media.genres();
-        this.color = media.coverImage().color();
+        this.color = Objects.requireNonNull(media.coverImage()).color();
         this.episodes = media.episodes();
     }
 
@@ -111,10 +107,6 @@ public class Anime {
     public String getTitleEnglish() {
         return titleEnglish != null? titleEnglish: titleRomaji;
     }
-
-    public String getTitleRomaji() { return titleRomaji; }
-
-    public String getTitleNative() { return titleNative; }
 
     public String getDescription() {
         return description;

--- a/app/src/main/java/com/example/myanimereport/models/BacklogItem.java
+++ b/app/src/main/java/com/example/myanimereport/models/BacklogItem.java
@@ -5,10 +5,13 @@ import androidx.annotation.NonNull;
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
+import com.example.MediaDetailsByIdListQuery;
 import com.example.MediaDetailsByIdQuery;
 import com.parse.ParseClassName;
 import com.parse.ParseObject;
 import com.parse.ParseUser;
+import java.util.ArrayList;
+import java.util.List;
 
 /* BacklogItem (Parse model). */
 @ParseClassName("BacklogItem")
@@ -27,19 +30,44 @@ public class BacklogItem extends ParseObject {
     }
 
     public void setAnime() {
-        System.out.println("SET ANIME");
         ParseApplication.apolloClient.query(new MediaDetailsByIdQuery(getMediaId())).enqueue(
-                new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
-                    @Override
-                    public void onResponse(@NonNull Response<MediaDetailsByIdQuery.Data> response) {
-                        anime = new Anime(response);
-                    }
+            new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
+                @Override
+                public void onResponse(@NonNull Response<MediaDetailsByIdQuery.Data> response) {
+                    anime = new Anime(response);
+                }
 
-                    @Override
-                    public void onFailure(@NonNull ApolloException e) {
-                        Log.e("Apollo", e.getMessage());
+                @Override
+                public void onFailure(@NonNull ApolloException e) {
+                    Log.e("Apollo", e.getMessage());
+                }
+            }
+        );
+    }
+
+    public static void setAnimes(List<BacklogItem> items) {
+        System.out.println("Set animes.");
+        List<Integer> ids = new ArrayList<>();
+        for (BacklogItem item: items) ids.add(item.getMediaId());
+        ParseApplication.apolloClient.query(new MediaDetailsByIdListQuery(1, ids)).enqueue(
+            new ApolloCall.Callback<MediaDetailsByIdListQuery.Data>() {
+                @Override
+                public void onResponse(@NonNull Response<MediaDetailsByIdListQuery.Data> response) {
+                    if (response.getData().Page() == null) return;
+                    if (response.getData().Page().media() == null) return;
+                    for (MediaDetailsByIdListQuery.Medium m: response.getData().Page().media()) {
+                        Anime anime = new Anime(m.fragments().mediaFragment());
+                        ParseApplication.seenMediaIds.add(anime.getMediaId());
+                        int index = ids.indexOf(anime.getMediaId());
+                        items.get(index).setAnime(anime);
                     }
                 }
+
+                @Override
+                public void onFailure(@NonNull ApolloException e) {
+                    Log.e("Apollo", e.getMessage() + e.getCause());
+                }
+            }
         );
     }
 

--- a/app/src/main/java/com/example/myanimereport/models/BacklogItem.java
+++ b/app/src/main/java/com/example/myanimereport/models/BacklogItem.java
@@ -46,7 +46,6 @@ public class BacklogItem extends ParseObject {
     }
 
     public static void setAnimes(List<BacklogItem> items) {
-        System.out.println("Set animes.");
         List<Integer> ids = new ArrayList<>();
         for (BacklogItem item: items) ids.add(item.getMediaId());
         ParseApplication.apolloClient.query(new MediaDetailsByIdListQuery(1, ids)).enqueue(

--- a/app/src/main/java/com/example/myanimereport/models/Entry.java
+++ b/app/src/main/java/com/example/myanimereport/models/Entry.java
@@ -47,7 +47,6 @@ public class Entry extends ParseObject {
     }
 
     public void setAnime() {
-        System.out.println("SET ANIME");
         ParseApplication.apolloClient.query(new MediaDetailsByIdQuery(getMediaId())).enqueue(
             new ApolloCall.Callback<MediaDetailsByIdQuery.Data>() {
                 @Override
@@ -64,7 +63,6 @@ public class Entry extends ParseObject {
     }
 
     public static void setAnimes(List<Entry> entries) {
-        System.out.println("Set animes.");
         List<Integer> ids = new ArrayList<>();
         for (Entry entry: entries) ids.add(entry.getMediaId());
         ParseApplication.apolloClient.query(new MediaDetailsByIdListQuery(1, ids)).enqueue(

--- a/app/src/main/java/com/example/myanimereport/models/Entry.java
+++ b/app/src/main/java/com/example/myanimereport/models/Entry.java
@@ -5,10 +5,16 @@ import androidx.annotation.NonNull;
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
+import com.example.MediaAllQuery;
+import com.example.MediaDetailsByIdListQuery;
 import com.example.MediaDetailsByIdQuery;
 import com.parse.ParseClassName;
 import com.parse.ParseObject;
 import com.parse.ParseUser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /* Entry (Parse model). */
 @ParseClassName("Entry")
@@ -52,6 +58,29 @@ public class Entry extends ParseObject {
                 @Override
                 public void onFailure(@NonNull ApolloException e) {
                     Log.e("Apollo", e.getMessage());
+                }
+            }
+        );
+    }
+
+    public static void setAnimes(List<Entry> entries) {
+        List<Integer> ids = new ArrayList<>();
+        for (Entry entry: entries) ids.add(entry.getMediaId());
+        ParseApplication.apolloClient.query(new MediaDetailsByIdListQuery(1, ids)).enqueue(
+            new ApolloCall.Callback<MediaDetailsByIdListQuery.Data>() {
+                @Override
+                public void onResponse(@NonNull Response<MediaDetailsByIdListQuery.Data> response) {
+                    for (MediaDetailsByIdListQuery.Medium m: response.getData().Page().media()) {
+                        Anime anime = new Anime(m.fragments().mediaFragment());
+                        ParseApplication.seenMediaIds.add(anime.getMediaId());
+                        int index = ids.indexOf(anime.getMediaId());
+                        entries.get(index).setAnime(anime);
+                    }
+                }
+
+                @Override
+                public void onFailure(@NonNull ApolloException e) {
+                    Log.e("Apollo", e.getMessage() + e.getCause());
                 }
             }
         );

--- a/app/src/main/java/com/example/myanimereport/models/Entry.java
+++ b/app/src/main/java/com/example/myanimereport/models/Entry.java
@@ -64,12 +64,15 @@ public class Entry extends ParseObject {
     }
 
     public static void setAnimes(List<Entry> entries) {
+        System.out.println("Set animes.");
         List<Integer> ids = new ArrayList<>();
         for (Entry entry: entries) ids.add(entry.getMediaId());
         ParseApplication.apolloClient.query(new MediaDetailsByIdListQuery(1, ids)).enqueue(
             new ApolloCall.Callback<MediaDetailsByIdListQuery.Data>() {
                 @Override
                 public void onResponse(@NonNull Response<MediaDetailsByIdListQuery.Data> response) {
+                    if (response.getData().Page() == null) return;
+                    if (response.getData().Page().media() == null) return;
                     for (MediaDetailsByIdListQuery.Medium m: response.getData().Page().media()) {
                         Anime anime = new Anime(m.fragments().mediaFragment());
                         ParseApplication.seenMediaIds.add(anime.getMediaId());


### PR DESCRIPTION
# Overview
* This greatly reduced the number of AniList API requests by querying 50 animes at a time instead of one at a time
  * This was done using the `id_in: [Int]` argument rather than the `id: Int` argument I had been using
* I also added null checking across all files (whenever I'm trying to access data retrieved from databases) to prevent the app from breaking

# Performance
* The app's features didn't really change, but performance increased
  * Before: user with 100 entries needed 100 requests for anime information, exceeding the rate limit of 90 requests per minute
  * After: user with 100 entries needs only 2 requests for anime information (can query 50 at a time using pagination)