### PR TITLE
[Ready for Review] Improved performance of Slope One by precalculating intermediate data

### DIFF
--- a/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
+++ b/app/src/main/java/com/example/myanimereport/activities/EntryActivity.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
@@ -23,8 +24,12 @@ import com.example.myanimereport.R;
 import com.example.myanimereport.adapters.AnimesAdapter;
 import com.example.myanimereport.databinding.ActivityEntryBinding;
 import com.example.myanimereport.models.Anime;
+import com.example.myanimereport.models.AnimePair;
 import com.example.myanimereport.models.Entry;
 import com.example.myanimereport.models.ParseApplication;
+import com.parse.ParseQuery;
+import com.parse.ParseUser;
+
 import org.parceler.Parcels;
 import java.text.DateFormatSymbols;
 import java.util.ArrayList;
@@ -246,6 +251,42 @@ public class EntryActivity extends AppCompatActivity {
 
     /* Creates a new entry, saves it, and return to the home list. */
     public void createNewEntry(Integer month, Integer year, Double rating, String note) {
+        for (Entry otherEntry: ParseApplication.entries) {
+            ParseQuery<AnimePair> query1 = ParseQuery.getQuery(AnimePair.class);
+            query1.whereEqualTo("mediaId1", mediaId);
+            query1.whereEqualTo("mediaId2", otherEntry.getMediaId());
+            ParseQuery<AnimePair> query2 = ParseQuery.getQuery(AnimePair.class);
+            query2.whereEqualTo("mediaId2", mediaId);
+            query2.whereEqualTo("mediaId1", otherEntry.getMediaId());
+            List<ParseQuery<AnimePair>> list = new ArrayList<>();
+            list.add(query1);
+            list.add(query2);
+            ParseQuery<AnimePair> query = ParseQuery.or(list);
+            query.findInBackground((pairs, e) -> { // Start async query for entries
+                // Check for errors
+                if (e != null) {
+                    Log.e("EntryActivity", "Error when getting anime pairs.", e);
+                    return;
+                }
+
+                double diff = rating - otherEntry.getRating();
+                if (pairs.size() > 0) {
+                    AnimePair pair = pairs.get(0);
+                    int sign = pair.getMediaId1().equals(mediaId)? 1: -1;
+                    pair.setCount(pair.getCount() + 1);
+                    pair.setDiffSum(pair.getDiffSum() + sign * diff);
+                    pair.saveInBackground();
+                } else {
+                    AnimePair pair = new AnimePair();
+                    pair.setMediaId1(mediaId);
+                    pair.setMediaId2(otherEntry.getMediaId());
+                    pair.setCount(1);
+                    pair.setDiffSum(diff);
+                    pair.saveInBackground();
+                }
+            });
+        }
+
         entry = new Entry(mediaId, month, year, rating, note);
         entry.setAnime();
         entry.saveInBackground(e -> {

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -162,7 +162,6 @@ public class HomeFragment extends Fragment {
     public void queryEntries(boolean firstQuery) {
         if (firstQuery) showProgressBar();
         ParseQuery<Entry> query = ParseQuery.getQuery(Entry.class); // Specify type of data
-        query.whereEqualTo(Entry.KEY_USER, ParseUser.getCurrentUser()); // Limit entries to current user's
         query.addDescendingOrder("createdAt"); // Order posts by creation date
         query.findInBackground((entriesFound, e) -> { // Start async query for entries
             // Check for errors
@@ -171,10 +170,18 @@ public class HomeFragment extends Fragment {
                 return;
             }
 
+            List<Entry> userEntries = new ArrayList<>();
+            for (Entry entry: entriesFound) {
+                ParseApplication.entryMediaIdAllUsers.add(entry.getMediaId());
+                if (entry.getUser().getObjectId().equals(ParseUser.getCurrentUser().getObjectId())) {
+                    userEntries.add(entry);
+                }
+            }
+
             // Add entries to the recycler view and notify its adapter of new data
-            Entry.setAnimes(entriesFound);
-            allEntries.addAll(entriesFound);
-            entries.addAll(entriesFound);
+            Entry.setAnimes(userEntries);
+            allEntries.addAll(userEntries);
+            entries.addAll(userEntries);
             adapter.notifyDataSetChanged();
             checkEntriesExist();
             binding.swipeContainer.setRefreshing(false);

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -170,6 +170,7 @@ public class HomeFragment extends Fragment {
                 return;
             }
 
+            // Keep track of seen anime ids of all users (for Slope One)
             List<Entry> userEntries = new ArrayList<>();
             for (Entry entry: entriesFound) {
                 ParseApplication.entryMediaIdAllUsers.add(entry.getMediaId());

--- a/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/myanimereport/fragments/HomeFragment.java
@@ -305,6 +305,7 @@ public class HomeFragment extends Fragment {
         selectedGenres.clear();
         adapter.notifyItemInserted(0);
         binding.rvEntries.smoothScrollToPosition(0);
+        checkEntriesExist();
     }
 
     /* After returning from a entry activity, update the entry at its position. */

--- a/app/src/main/java/com/example/myanimereport/models/AnimePair.java
+++ b/app/src/main/java/com/example/myanimereport/models/AnimePair.java
@@ -1,0 +1,49 @@
+package com.example.myanimereport.models;
+
+import com.parse.ParseClassName;
+import com.parse.ParseObject;
+import com.parse.ParseUser;
+
+/* PairCount (Parse model). */
+@ParseClassName("AnimePair")
+public class AnimePair extends ParseObject {
+    public static final String KEY_MEDIA_ID1 = "mediaId1";
+    public static final String KEY_MEDIA_ID2 = "mediaId2";
+    public static final String KEY_COUNT = "count";
+    public static final String KEY_DIFF_SUM = "diffSum";
+
+    /* Default constructor required by Parse. */
+    public AnimePair() { }
+
+    public Integer getMediaId1() {
+        return getInt(KEY_MEDIA_ID1);
+    }
+
+    public void setMediaId1(Integer mediaId) {
+        put(KEY_MEDIA_ID1, mediaId);
+    }
+
+    public Integer getMediaId2() {
+        return getInt(KEY_MEDIA_ID2);
+    }
+
+    public void setMediaId2(Integer mediaId) {
+        put(KEY_MEDIA_ID2, mediaId);
+    }
+
+    public Integer getCount() {
+        return getInt(KEY_COUNT);
+    }
+
+    public void setCount(Integer count) {
+        put(KEY_COUNT, count);
+    }
+
+    public Double getDiffSum() {
+        return getDouble(KEY_DIFF_SUM);
+    }
+
+    public void setDiffSum(Double diffSum) {
+        put(KEY_DIFF_SUM, diffSum);
+    }
+}

--- a/app/src/main/java/com/example/myanimereport/models/AnimePair.java
+++ b/app/src/main/java/com/example/myanimereport/models/AnimePair.java
@@ -4,7 +4,7 @@ import com.parse.ParseClassName;
 import com.parse.ParseObject;
 import com.parse.ParseUser;
 
-/* PairCount (Parse model). */
+/* PairCount (Parse model). For storing intermediate data for Slope One. */
 @ParseClassName("AnimePair")
 public class AnimePair extends ParseObject {
     public static final String KEY_MEDIA_ID1 = "mediaId1";

--- a/app/src/main/java/com/example/myanimereport/models/ParseApplication.java
+++ b/app/src/main/java/com/example/myanimereport/models/ParseApplication.java
@@ -21,6 +21,7 @@ public class ParseApplication extends Application {
     public static List<BacklogItem> backlogItems;
     public static List<Integer> seenMediaIds;
     public static Set<String> genres;
+    public static Set<Integer> entryMediaIdAllUsers;
 
     @Override
     public void onCreate() {
@@ -30,6 +31,7 @@ public class ParseApplication extends Application {
         ParseObject.registerSubclass(Entry.class);
         ParseObject.registerSubclass(BacklogItem.class);
         ParseObject.registerSubclass(Rejection.class);
+        ParseObject.registerSubclass(AnimePair.class);
 
         // Initialize the parse application
         Parse.initialize(new Parse.Configuration.Builder(this)
@@ -47,6 +49,7 @@ public class ParseApplication extends Application {
         backlogItems = new ArrayList<>();
         seenMediaIds = new ArrayList<>();
         genres = new HashSet<>();
+        entryMediaIdAllUsers = new HashSet<>();
 
         // Register callback to keep the current activity updated
         registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {


### PR DESCRIPTION
# Overview
* [x] Created a class `AnimePair` in Parse. For each pair of animes (rated by at least one user),
  * [x] Stored the number of users who rated both animes (field `count`)
  * [x] Stored the sum of rating difference between the two animes (field `diffSum`) 
  * [x] Whenever an entry is created, updated relevant `count` and `diffSum`
* [x] When predicting ratings in Slope One, used the precalculated `count` and `diffSum` to find average rating differences

# Results
* This greatly improved the performance of the Slope One recommender algorithm. With ~10 users and ~100 rated animes,
  * Before, it took ~12 seconds to generate the recommended anime list.
  * Now, it takes ~2 seconds to generate the recommended anime list.

# Next Steps
* Update `count` and `diffSum` upon entry edit/deletion for even more accuracy
* Incorporate [k-nearest-neighbors](https://link.springer.com/chapter/10.1007/978-3-642-28635-3_15)

# Screen Recording
![recsys-precalculated](https://user-images.githubusercontent.com/59420335/128089902-fc5cf06b-ee99-4794-9cd5-bfb998084135.gif)

